### PR TITLE
Document desktop prerequisites and add onboarding wizard

### DIFF
--- a/docs/desktop/INSTALLATION.md
+++ b/docs/desktop/INSTALLATION.md
@@ -1,0 +1,88 @@
+# Desktop Runtime Installation & Environment Validation
+
+This document captures the exploratory work required to onboard Agent Zero's
+desktop runtime onto developer machines. It summarizes the feasibility of
+shipping Podman directly, enumerates platform prerequisites, and introduces a
+prototype onboarding wizard that can evolve into an automated installer.
+
+## 1. Feasibility: Ship Podman vs. Trigger Installation
+
+### Option A — Bundle a minimal Podman runtime
+
+| Platform | Status | Notes |
+| --- | --- | --- |
+| Windows | ⚠️ Feasible with effort | Requires distributing `podman-remote.exe`, the `podman machine` assets, and provisioning a WSL2 VM. Shipping a custom VM image increases the download size (~800 MB) and demands driver updates for each Windows build. Maintenance burden is high because security updates must be re-issued promptly. |
+| macOS | ⚠️ Feasible but heavy | Podman on macOS depends on the Apple Hypervisor framework plus a Lima VM. Shipping a trimmed Lima + QEMU bundle is possible, yet notarization and Rosetta compatibility tests are required. Continuous updates for each Podman release would fall on us. |
+| Linux | ✅ Straightforward | Native Podman packages are available on most distributions. A portable static build could be shipped, but distro package managers already provide timely updates. |
+
+**Risks:**
+
+* Larger application footprint (hundreds of megabytes) and longer install times.
+* We become responsible for Podman CVE response times and OS-specific packaging.
+* Requires implementing privileged setup steps (WSL2 features, kernel modules) that the app cannot perform without elevated permissions.
+
+### Option B — Trigger official Podman Desktop or Engine installation
+
+| Platform | Status | Notes |
+| --- | --- | --- |
+| Windows | ✅ Recommended | Podman Desktop installer handles enabling WSL2 integration and ships signed binaries. We can deep-link to `podman-desktop.exe` or invoke `winget install -e --id RedHat.Podman-Desktop`. |
+| macOS | ✅ Recommended | Podman Desktop (`.dmg`) or Homebrew packages manage the Lima VM and virtualization entitlements. Trigger downloads via `brew install podman-desktop` or open the DMG URL in the browser. |
+| Linux | ✅ Recommended | Point users to `dnf`, `apt`, or `pacman` commands; optional `brew` on Linux. No need to ship binaries ourselves. |
+
+**Benefits:**
+
+* Offloads maintenance and security updates to Podman's official channels.
+* Reuses platform-native installers with proper code signing.
+* Reduces our download size and legal/licensing footprint.
+
+**Conclusion:** Triggering the official Podman Desktop/Engine installers is the
+preferred approach. Shipping our own runtime should be considered only for fully
+offline deployments and would require a dedicated maintenance plan.
+
+## 2. Platform Prerequisites
+
+| Platform | Virtualization | Container Runtime | Additional Requirements |
+| --- | --- | --- | --- |
+| Windows 11 / Windows 10 21H2+ | BIOS/UEFI virtualization (Intel VT-x/AMD-V), Hyper-V, Virtual Machine Platform, and WSL2 enabled. | Docker Desktop, Docker Engine (via WSL), or Podman Desktop/Engine. | Latest Windows updates, admin rights to install optional features. |
+| macOS 12+ (Intel & Apple Silicon) | Apple Hypervisor framework enabled; Rosetta 2 for Apple Silicon when running x86_64 images. | Docker Desktop, Colima, Rancher Desktop, or Podman Desktop. | Xcode Command Line Tools recommended for virtualization drivers; internet access for Rosetta install. |
+| Linux (Fedora, Ubuntu 22.04+, Arch, etc.) | Kernel with KVM modules, `/dev/kvm` accessible to the user, cgroups v2 enabled. | Podman 4+, Docker Engine 24+, or compatible OCI runtime. | User must belong to `docker`, `podman`, or `libvirt` groups depending on distribution. |
+
+**General prerequisites:**
+
+* 8 GB RAM minimum, 16 GB recommended for simultaneous IDE and container usage.
+* 10 GB free disk space for base images and build cache.
+* Stable internet connection for pulling container images and dependency updates.
+
+## 3. Onboarding Wizard Prototype
+
+A command-line prototype is provided at
+[`python/tools/desktop_onboarding.py`](../../python/tools/desktop_onboarding.py)
+that can be wrapped by the desktop UI. The wizard performs the following steps:
+
+1. Detects virtualization support (Hyper-V/WSL2 on Windows, Hypervisor.framework on macOS, KVM on Linux).
+2. Checks for Docker and Podman binaries on the `PATH`, reporting versions if present.
+3. Validates runtime permissions by running `docker info` or `podman info` on the preferred runtime.
+4. Outputs remediation guidance for any missing or warning conditions.
+
+Run the prototype directly from the repository root:
+
+```bash
+python -m python.tools.desktop_onboarding --runtime podman
+```
+
+The exit code indicates readiness (`0` success, `1` warnings, `2` missing critical
+components), making it suitable for automated diagnostics or CI gating.
+
+## 4. Next Steps
+
+* Integrate the CLI checks into the desktop application's onboarding flow with a
+  guided UI (progress steps, contextual help, inline remediation links).
+* Detect whether Podman Desktop or Docker Desktop is already running and offer to
+  launch it for the user.
+* Offer one-click commands (`winget`, `brew`, distro package managers) directly
+  from the UI once the user approves elevated operations.
+* Extend virtualization checks with richer telemetry (e.g., CPU compatibility,
+  virtualization-based security conflicts) before provisioning local containers.
+
+The findings above should inform future implementation work and any automated
+installers we decide to ship.

--- a/python/tools/desktop_onboarding.py
+++ b/python/tools/desktop_onboarding.py
@@ -1,0 +1,291 @@
+"""CLI prototype for desktop onboarding checks.
+
+This script walks users through the prerequisites for running Agent Zero's
+containerized runtime, validating the host environment for Docker or Podman.
+It is intentionally conservative and designed to be extended by the desktop
+application later.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from typing import Iterable, Optional
+
+
+@dataclasses.dataclass
+class CheckResult:
+    """Outcome of a wizard check step."""
+
+    title: str
+    status: str
+    details: str
+    remediation: Optional[str] = None
+
+    def format(self) -> str:
+        lines = [f"- {self.title}: {self.status}"]
+        if self.details:
+            lines.append(f"    {self.details}")
+        if self.remediation:
+            lines.append(f"    👉 {self.remediation}")
+        return "\n".join(lines)
+
+
+def run_command(command: Iterable[str]) -> subprocess.CompletedProcess[str]:
+    """Run a command and capture stdout, returning a completed process.
+
+    The function never raises and instead returns the completed process. If the
+    command cannot be executed an artificial result with return code 127 is
+    returned.
+    """
+
+    try:
+        return subprocess.run(
+            list(command),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - platform dependent
+        return subprocess.CompletedProcess(  # type: ignore[arg-type]
+            args=list(command),
+            returncode=127,
+            stdout=str(exc),
+        )
+
+
+def check_for_cli(binary: str, friendly_name: str) -> CheckResult:
+    """Check whether the given CLI exists and report version information."""
+
+    path = shutil.which(binary)
+    if not path:
+        return CheckResult(
+            title=f"{friendly_name} availability",
+            status="missing",
+            details=f"`{binary}` was not found on PATH.",
+            remediation=f"Install {friendly_name} and ensure `{binary}` is available on PATH.",
+        )
+
+    proc = run_command([binary, "--version"])
+    version = proc.stdout.strip() or "unknown version"
+    status = "ok" if proc.returncode == 0 else "warning"
+    details = f"Found at {path}: {version}."
+    remediation = None
+    if proc.returncode != 0:
+        remediation = f"Running `{binary} --version` returned exit code {proc.returncode}."
+    return CheckResult(
+        title=f"{friendly_name} availability",
+        status=status,
+        details=details,
+        remediation=remediation,
+    )
+
+
+def _check_virtualization_windows() -> CheckResult:
+    """Check virtualization prerequisites for Windows."""
+
+    hv_proc = run_command([
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        "(Get-CimInstance -ClassName Win32_ComputerSystem).HypervisorPresent",
+    ])
+    if hv_proc.returncode == 0 and "True" in hv_proc.stdout:
+        hv_status = "enabled"
+    elif hv_proc.returncode == 0:
+        hv_status = "disabled"
+    else:
+        hv_status = "unknown"
+
+    wsl_proc = run_command(["wsl.exe", "--status"])
+    wsl_ok = wsl_proc.returncode == 0 and "Default Version: 2" in wsl_proc.stdout
+    details = [
+        f"Hyper-V virtualization: {hv_status}.",
+        "WSL status: available" if wsl_proc.returncode == 0 else "WSL status: unavailable",
+    ]
+    if wsl_proc.returncode == 0 and not wsl_ok:
+        details.append("Default WSL version is not 2. Run `wsl --set-default-version 2`.")
+
+    remediation = None
+    if hv_status != "enabled":
+        remediation = (
+            "Enable virtualization in BIOS/UEFI and ensure Hyper-V, Virtual Machine Platform, "
+            "and Windows Subsystem for Linux optional features are enabled."
+        )
+    return CheckResult(
+        title="Windows virtualization stack",
+        status="ok" if hv_status == "enabled" and wsl_proc.returncode == 0 else "warning",
+        details=" ".join(details),
+        remediation=remediation,
+    )
+
+
+def _check_virtualization_macos() -> CheckResult:
+    """Check virtualization prerequisites for macOS."""
+
+    hv_proc = run_command(["sysctl", "-n", "kern.hv_support"])
+    hv_enabled = hv_proc.returncode == 0 and hv_proc.stdout.strip() == "1"
+
+    architecture = platform.processor() or platform.machine()
+    rosetta_proc = None
+    if architecture and architecture.lower().startswith("arm"):
+        rosetta_proc = run_command([
+            "pkgutil",
+            "--files",
+            "com.apple.pkg.RosettaUpdateAuto",
+        ])
+    details_parts = [
+        f"Hardware virtualization framework: {'available' if hv_enabled else 'unavailable'}.",
+    ]
+    remediation = None
+    if not hv_enabled:
+        remediation = "Rosetta/Intel virtualization not detected. Ensure hardware virtualization is enabled."
+
+    if rosetta_proc is not None:
+        if rosetta_proc.returncode == 0:
+            details_parts.append("Rosetta 2: installed.")
+        else:
+            details_parts.append("Rosetta 2: not detected. Install via `softwareupdate --install-rosetta`.")
+            remediation = (
+                remediation
+                or "Install Rosetta 2 to allow running Intel-based container images on Apple Silicon."
+            )
+
+    return CheckResult(
+        title="macOS virtualization stack",
+        status="ok" if hv_enabled else "warning",
+        details=" ".join(details_parts),
+        remediation=remediation,
+    )
+
+
+def _check_virtualization_linux() -> CheckResult:
+    """Check virtualization prerequisites for Linux hosts."""
+
+    cpuinfo_flags = ""
+    try:
+        with open("/proc/cpuinfo", "r", encoding="utf-8") as handle:
+            cpuinfo_flags = handle.read()
+    except OSError:
+        cpuinfo_flags = ""
+
+    hv_capable = "vmx" in cpuinfo_flags or "svm" in cpuinfo_flags
+    kvm_access = os.path.exists("/dev/kvm") and os.access("/dev/kvm", os.R_OK | os.W_OK)
+    details = [
+        f"CPU virtualization extensions: {'present' if hv_capable else 'absent'}.",
+        f"/dev/kvm access: {'ok' if kvm_access else 'restricted'}.",
+    ]
+    remediation_parts = []
+    if not hv_capable:
+        remediation_parts.append("Enable virtualization extensions (Intel VT-x/AMD-V) in BIOS/UEFI.")
+    if not kvm_access:
+        remediation_parts.append("Ensure the current user belongs to the `kvm` group and that the module is loaded.")
+    remediation = " ".join(remediation_parts) if remediation_parts else None
+    return CheckResult(
+        title="Linux virtualization stack",
+        status="ok" if hv_capable and kvm_access else "warning",
+        details=" ".join(details),
+        remediation=remediation,
+    )
+
+
+def check_virtualization() -> CheckResult:
+    system = platform.system()
+    if system == "Windows":
+        return _check_virtualization_windows()
+    if system == "Darwin":
+        return _check_virtualization_macos()
+    return _check_virtualization_linux()
+
+
+def check_user_permissions(cli_name: str) -> CheckResult:
+    """Attempt to run an info command to detect permission issues."""
+
+    info_command = [cli_name, "info"]
+    proc = run_command(info_command)
+    if proc.returncode == 0:
+        return CheckResult(
+            title=f"{cli_name} permissions",
+            status="ok",
+            details=f"`{cli_name} info` executed successfully.",
+        )
+
+    remediation = (
+        "The command failed. Ensure the service is running and the current user has permissions."
+    )
+    if platform.system() == "Linux":
+        remediation += " Add the user to the `docker` or `podman` group and relogin."
+
+    return CheckResult(
+        title=f"{cli_name} permissions",
+        status="warning",
+        details=proc.stdout.strip() or "Command returned a non-zero exit code.",
+        remediation=remediation,
+    )
+
+
+def run_wizard(preferred_runtime: Optional[str] = None) -> int:
+    """Run the onboarding wizard and print the collected results."""
+
+    checks = []
+    virtualization = check_virtualization()
+    checks.append(virtualization)
+
+    docker = check_for_cli("docker", "Docker")
+    podman = check_for_cli("podman", "Podman")
+    checks.extend([docker, podman])
+
+    runtime = preferred_runtime
+    if runtime not in {"docker", "podman"}:
+        runtime = "podman" if podman.status == "ok" else "docker"
+        if preferred_runtime and runtime != preferred_runtime:
+            print(
+                f"Preferred runtime `{preferred_runtime}` unavailable, falling back to `{runtime}`.",
+                file=sys.stderr,
+            )
+
+    if runtime == "docker" and docker.status != "missing":
+        checks.append(check_user_permissions("docker"))
+    elif runtime == "podman" and podman.status != "missing":
+        checks.append(check_user_permissions("podman"))
+
+    print("Agent Zero Desktop environment report:\n")
+    for check in checks:
+        print(check.format())
+        print()
+
+    failing = [c for c in checks if c.status == "missing"]
+    warnings = [c for c in checks if c.status == "warning"]
+
+    if failing:
+        print("Some critical components are missing. Follow the remediation guidance above.")
+        return 2
+    if warnings:
+        print("Environment has warnings. Address them for the best experience.")
+        return 1
+    print("All checks passed. You're ready to run the desktop runtime!")
+    return 0
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Agent Zero desktop onboarding checks")
+    parser.add_argument(
+        "--runtime",
+        choices=["docker", "podman"],
+        help="Preferred container runtime to validate first.",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    return run_wizard(preferred_runtime=args.runtime)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- capture the trade-offs of bundling Podman versus invoking official installers and record platform prerequisites in `docs/desktop/INSTALLATION.md`
- add a CLI onboarding prototype that audits virtualization support, Docker/Podman availability, and runtime permissions

## Testing
- python -m python.tools.desktop_onboarding --runtime podman *(fails in container because Docker/Podman and virtualization are unavailable, wizard reports guidance as designed)*

------
https://chatgpt.com/codex/tasks/task_e_68f2af43841c832e806fa70d76e819b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation and environment validation guide with platform-specific prerequisites and requirements for Windows, macOS, and Linux.

* **New Features**
  * Added desktop onboarding validation tool that checks virtualization support, container runtime availability, and user permissions across platforms, providing remediation guidance for configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->