### PR TITLE
Add desktop Docker orchestration and status UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ instruments/**
 # Global rule to include .gitkeep files anywhere
 !**/.gitkeep
 agent_history.gif
+desktop/node_modules/
+desktop/dist/

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,0 +1,899 @@
+{
+  "name": "agent-zero-desktop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-zero-desktop",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/electron": "^1.6.10",
+        "@types/node": "^20.11.30",
+        "electron": "^29.1.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/electron": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@types/electron/-/electron-1.6.12.tgz",
+      "integrity": "sha512-NIJokDkGv9h+MStCL1IuiL1FOHYVkszoWeNxJtSI5dcEKRGbX83JcVYNAgk019qOQgJkHtz9WdP0CDXvrArrGg==",
+      "deprecated": "This is a stub types definition. electron provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "electron": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
+      "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.6.tgz",
+      "integrity": "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-zero-desktop",
+  "version": "0.1.0",
+  "description": "Agent Zero desktop application",
+  "main": "dist/main/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "npm run build && electron ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/electron": "^1.6.10",
+    "electron": "^29.1.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/desktop/src/common/dockerTypes.ts
+++ b/desktop/src/common/dockerTypes.ts
@@ -1,0 +1,57 @@
+export const DEFAULT_IMAGE = "agent0ai/agent-zero:latest";
+export const DEFAULT_CONTAINER_NAME = "agent-zero";
+export const DEFAULT_PORT = 50001;
+
+export type DockerProgressKind = "info" | "error" | "success";
+
+export interface DockerProgressEvent {
+  kind: DockerProgressKind;
+  message: string;
+}
+
+export interface DockerContainerInfo {
+  id: string;
+  name: string;
+  image: string;
+  state: string;
+  status: string;
+  createdAt?: string;
+  runningFor?: string;
+  ports?: string;
+}
+
+export interface DockerImageInfo {
+  id: string;
+  repository: string;
+  tag: string;
+  createdSince?: string;
+  createdAt?: string;
+  size?: string;
+}
+
+export interface DockerListResult {
+  containers: DockerContainerInfo[];
+  images: DockerImageInfo[];
+}
+
+export interface DockerOperationResult {
+  success: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface DockerRemoveResult {
+  removedContainer: boolean;
+  removedImage: boolean;
+}
+
+export interface IpcErrorPayload {
+  code: string;
+  message: string;
+  details?: string;
+}
+
+export interface IpcResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: IpcErrorPayload;
+}

--- a/desktop/src/main/dockerService.ts
+++ b/desktop/src/main/dockerService.ts
@@ -1,0 +1,299 @@
+import { execFile } from "child_process";
+import { spawn } from "child_process";
+import { promisify } from "util";
+import fs from "fs";
+import path from "path";
+import {
+  DEFAULT_CONTAINER_NAME,
+  DEFAULT_IMAGE,
+  DEFAULT_PORT,
+  DockerListResult,
+  DockerProgressEvent,
+  DockerRemoveResult,
+} from "../common/dockerTypes";
+
+const execFileAsync = promisify(execFile);
+
+export class DockerNotAvailableError extends Error {
+  public readonly code = "DOCKER_UNAVAILABLE";
+  constructor(message: string, public readonly details?: string) {
+    super(message);
+    this.name = "DockerNotAvailableError";
+  }
+}
+
+export class DockerCommandError extends Error {
+  public readonly code = "DOCKER_COMMAND_FAILED";
+  constructor(message: string, public readonly details?: string) {
+    super(message);
+    this.name = "DockerCommandError";
+  }
+}
+
+let dockerVerified = false;
+
+async function ensureDockerAvailable(): Promise<void> {
+  if (dockerVerified) {
+    return;
+  }
+
+  try {
+    await execFileAsync("docker", ["info"]);
+    dockerVerified = true;
+  } catch (error) {
+    throw normalizeDockerError(
+      error,
+      "Docker Desktop is not available. Please install or start Docker Desktop and try again."
+    );
+  }
+}
+
+function normalizeDockerError(error: unknown, defaultMessage: string, stderrText = ""): Error {
+  const err = error as NodeJS.ErrnoException & { stderr?: string };
+  const combinedMessage = [stderrText, err?.stderr].filter(Boolean).join("\n");
+  const message = combinedMessage || err?.message || defaultMessage;
+  if (err?.code === "ENOENT") {
+    dockerVerified = false;
+    return new DockerNotAvailableError(
+      "Docker CLI was not found. Install Docker Desktop and ensure the docker command is available in your PATH.",
+      message
+    );
+  }
+
+  if (/docker daemon is not running/i.test(message) || /cannot connect to the docker daemon/i.test(message)) {
+    dockerVerified = false;
+    return new DockerNotAvailableError(
+      "Docker Desktop does not appear to be running. Please launch Docker Desktop and wait for it to finish starting before retrying.",
+      message
+    );
+  }
+
+  if (/permission denied/i.test(message)) {
+    dockerVerified = false;
+    return new DockerNotAvailableError(
+      "Docker requires elevated permissions. Make sure your user has access to Docker or run Docker Desktop.",
+      message
+    );
+  }
+
+  return new DockerCommandError(defaultMessage, message);
+}
+
+async function runDockerCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  await ensureDockerAvailable();
+  try {
+    const { stdout, stderr } = await execFileAsync("docker", args, { maxBuffer: 1024 * 1024 * 20 });
+    return {
+      stdout: stdout?.toString() ?? "",
+      stderr: stderr?.toString() ?? "",
+    };
+  } catch (error) {
+    throw normalizeDockerError(error, `Failed to execute \"docker ${args.join(" ")}\".`);
+  }
+}
+
+export async function pullImage(onProgress?: (event: DockerProgressEvent) => void): Promise<void> {
+  await ensureDockerAvailable();
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("docker", ["pull", DEFAULT_IMAGE]);
+    let stderrBuffer = "";
+
+    const emit = (kind: DockerProgressEvent["kind"], message: string) => {
+      if (!message.trim()) {
+        return;
+      }
+      onProgress?.({ kind, message: message.trimEnd() });
+    };
+
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      text
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .forEach((line: string) => emit("info", line));
+    });
+
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderrBuffer += text;
+      text
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .forEach((line: string) => emit("error", line));
+    });
+
+    child.on("error", (error) => {
+      reject(normalizeDockerError(error, "Docker pull command could not start."));
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        emit("success", `Docker image ${DEFAULT_IMAGE} pulled successfully.`);
+        resolve();
+      } else {
+        reject(normalizeDockerError(new Error(`docker pull exited with code ${code}`), "Docker pull command failed.", stderrBuffer));
+      }
+    });
+  });
+}
+
+export async function startContainer(): Promise<{ containerId?: string; startedExisting: boolean }> {
+  await ensureDockerAvailable();
+  const existing = await getContainerId();
+  if (existing) {
+    await runDockerCommand(["start", DEFAULT_CONTAINER_NAME]);
+    return { containerId: existing, startedExisting: true };
+  }
+
+  const runArgs = [
+    "run",
+    "-d",
+    "--name",
+    DEFAULT_CONTAINER_NAME,
+    "-p",
+    DEFAULT_PORT + ":80",
+    DEFAULT_IMAGE,
+  ];
+
+  const { stdout } = await runDockerCommand(runArgs);
+  const containerId = stdout.trim();
+  return { containerId, startedExisting: false };
+}
+
+export async function stopContainer(): Promise<{ stopped: boolean }> {
+  await ensureDockerAvailable();
+  const existing = await getContainerId();
+  if (!existing) {
+    return { stopped: false };
+  }
+
+  try {
+    await runDockerCommand(["stop", DEFAULT_CONTAINER_NAME]);
+    return { stopped: true };
+  } catch (error) {
+    throw normalizeDockerError(error, "Failed to stop Docker container.");
+  }
+}
+
+export async function removeResources(): Promise<DockerRemoveResult> {
+  await ensureDockerAvailable();
+  let removedContainer = false;
+  let removedImage = false;
+
+  try {
+    const existing = await getContainerId();
+    if (existing) {
+      await runDockerCommand(["rm", "-f", DEFAULT_CONTAINER_NAME]);
+      removedContainer = true;
+    }
+  } catch (error) {
+    const normalized = normalizeDockerError(error, "Failed to remove Docker container.");
+    if (normalized instanceof DockerCommandError && normalized.details?.includes("No such container")) {
+      // treat as already removed
+    } else {
+      throw normalized;
+    }
+  }
+
+  try {
+    await runDockerCommand(["rmi", DEFAULT_IMAGE]);
+    removedImage = true;
+  } catch (error) {
+    const normalized = normalizeDockerError(error, "Failed to remove Docker image.");
+    if (normalized instanceof DockerCommandError && normalized.details?.includes("No such image")) {
+      // ignore missing image
+    } else {
+      throw normalized;
+    }
+  }
+
+  return { removedContainer, removedImage };
+}
+
+export async function listDockerResources(): Promise<DockerListResult> {
+  await ensureDockerAvailable();
+  const [containersOutput, imagesOutput] = await Promise.all([
+    runDockerCommand([
+      "ps",
+      "-a",
+      "--format",
+      "{{json .}}",
+      "--filter",
+      "name=" + DEFAULT_CONTAINER_NAME,
+    ]),
+    runDockerCommand(["images", "--format", "{{json .}}", "agent0ai/agent-zero"]),
+  ]);
+
+  const containers = containersOutput.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        return {
+          id: parsed.ID as string,
+          name: parsed.Names as string,
+          image: parsed.Image as string,
+          state: parsed.State as string,
+          status: parsed.Status as string,
+          createdAt: parsed.CreatedAt as string | undefined,
+          runningFor: parsed.RunningFor as string | undefined,
+          ports: parsed.Ports as string | undefined,
+        };
+      } catch (error) {
+        throw new DockerCommandError("Failed to parse docker ps output.", String(error));
+      }
+    });
+
+  const images = imagesOutput.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        return {
+          id: parsed.ID as string,
+          repository: parsed.Repository as string,
+          tag: parsed.Tag as string,
+          createdSince: parsed.CreatedSince as string | undefined,
+          createdAt: parsed.CreatedAt as string | undefined,
+          size: parsed.Size as string | undefined,
+        };
+      } catch (error) {
+        throw new DockerCommandError("Failed to parse docker images output.", String(error));
+      }
+    });
+
+  return {
+    containers,
+    images,
+  };
+}
+
+async function getContainerId(): Promise<string | null> {
+  const { stdout } = await runDockerCommand([
+    "ps",
+    "-a",
+    "-q",
+    "--filter",
+    "name=^/" + DEFAULT_CONTAINER_NAME + "$",
+  ]);
+  const id = stdout.trim();
+  return id || null;
+}
+
+export function ensureRendererAssets(): void {
+  const projectRoot = path.resolve(__dirname, "..", "..");
+  const srcDir = path.join(projectRoot, "src", "renderer");
+  const destDir = path.join(projectRoot, "dist", "renderer");
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const assets = ["index.html", "styles.css"];
+  for (const asset of assets) {
+    const srcPath = path.join(srcDir, asset);
+    const destPath = path.join(destDir, asset);
+    if (fs.existsSync(srcPath)) {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,0 +1,40 @@
+import { app, BrowserWindow } from "electron";
+import path from "path";
+import { ensureRendererAssets } from "./dockerService";
+import { registerDockerIpcHandlers } from "./ipc";
+
+let mainWindow: BrowserWindow | null = null;
+
+async function createWindow(): Promise<void> {
+  ensureRendererAssets();
+
+  mainWindow = new BrowserWindow({
+    width: 1024,
+    height: 720,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  const rendererHtmlPath = path.join(__dirname, "../renderer/index.html");
+  await mainWindow.loadFile(rendererHtmlPath);
+}
+
+app.whenReady().then(async () => {
+  registerDockerIpcHandlers();
+  await createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      void createWindow();
+    }
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,0 +1,89 @@
+import { ipcMain, IpcMainInvokeEvent } from "electron";
+import {
+  DockerCommandError,
+  DockerNotAvailableError,
+  listDockerResources,
+  pullImage,
+  removeResources,
+  startContainer,
+  stopContainer,
+} from "./dockerService";
+import {
+  DockerListResult,
+  DockerProgressEvent,
+  DockerRemoveResult,
+  IpcErrorPayload,
+  IpcResponse,
+} from "../common/dockerTypes";
+
+function toErrorPayload(error: unknown): IpcErrorPayload {
+  if (error instanceof DockerNotAvailableError || error instanceof DockerCommandError) {
+    return {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+    };
+  }
+
+  const message = error instanceof Error ? error.message : "Unexpected error";
+  return {
+    code: "UNEXPECTED_ERROR",
+    message,
+    details: error instanceof Error && error.stack ? error.stack : undefined,
+  };
+}
+
+function wrapHandler<T>(handler: (event: IpcMainInvokeEvent) => Promise<IpcResponse<T>>): (event: IpcMainInvokeEvent) => Promise<IpcResponse<T>> {
+  return async (event) => {
+    try {
+      return await handler(event);
+    } catch (error) {
+      return { success: false, error: toErrorPayload(error) };
+    }
+  };
+}
+
+export function registerDockerIpcHandlers(): void {
+  ipcMain.handle(
+    "docker:pull",
+    wrapHandler<void>(async (event) => {
+      const sendProgress = (payload: DockerProgressEvent) => {
+        event.sender.send("docker:pull-progress", payload);
+      };
+      await pullImage(sendProgress);
+      return { success: true };
+    })
+  );
+
+  ipcMain.handle(
+    "docker:start",
+    wrapHandler(async () => {
+      const result = await startContainer();
+      return { success: true, data: result };
+    })
+  );
+
+  ipcMain.handle(
+    "docker:stop",
+    wrapHandler(async () => {
+      const result = await stopContainer();
+      return { success: true, data: result };
+    })
+  );
+
+  ipcMain.handle(
+    "docker:remove",
+    wrapHandler<DockerRemoveResult>(async () => {
+      const result = await removeResources();
+      return { success: true, data: result };
+    })
+  );
+
+  ipcMain.handle(
+    "docker:list",
+    wrapHandler<DockerListResult>(async () => {
+      const data = await listDockerResources();
+      return { success: true, data };
+    })
+  );
+}

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -1,0 +1,43 @@
+import { contextBridge, ipcRenderer, IpcRendererEvent } from "electron";
+import type {
+  DockerProgressEvent,
+  DockerListResult,
+  DockerRemoveResult,
+  IpcResponse,
+} from "../common/dockerTypes";
+
+function subscribe<T>(channel: string, listener: (event: IpcRendererEvent, payload: T) => void): () => void {
+  const wrapped = (event: IpcRendererEvent, ...args: unknown[]) => {
+    listener(event, args[0] as T);
+  };
+  ipcRenderer.on(channel, wrapped);
+  return () => {
+    ipcRenderer.removeListener(channel, wrapped);
+  };
+}
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  pullDockerImage: (): Promise<IpcResponse<void>> => ipcRenderer.invoke("docker:pull"),
+  startDockerContainer: (): Promise<IpcResponse<{ containerId?: string; startedExisting: boolean }>> =>
+    ipcRenderer.invoke("docker:start"),
+  stopDockerContainer: (): Promise<IpcResponse<{ stopped: boolean }>> => ipcRenderer.invoke("docker:stop"),
+  removeDockerResources: (): Promise<IpcResponse<DockerRemoveResult>> => ipcRenderer.invoke("docker:remove"),
+  listDockerResources: (): Promise<IpcResponse<DockerListResult>> => ipcRenderer.invoke("docker:list"),
+  onDockerPullProgress: (callback: (event: DockerProgressEvent) => void): (() => void) =>
+    subscribe<DockerProgressEvent>("docker:pull-progress", (_event, payload) => {
+      callback(payload);
+    }),
+});
+
+declare global {
+  interface Window {
+    electronAPI: {
+      pullDockerImage: () => Promise<IpcResponse<void>>;
+      startDockerContainer: () => Promise<IpcResponse<{ containerId?: string; startedExisting: boolean }>>;
+      stopDockerContainer: () => Promise<IpcResponse<{ stopped: boolean }>>;
+      removeDockerResources: () => Promise<IpcResponse<DockerRemoveResult>>;
+      listDockerResources: () => Promise<IpcResponse<DockerListResult>>;
+      onDockerPullProgress: (callback: (event: DockerProgressEvent) => void) => () => void;
+    };
+  }
+}

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agent Zero Desktop</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1>Agent Zero Docker Control</h1>
+        <button id="refresh" class="secondary">Refresh Status</button>
+      </header>
+      <section class="status-panel">
+        <div class="status-card">
+          <h2>Image</h2>
+          <p id="image-status" class="status-value">Checking...</p>
+          <p id="image-details" class="status-details"></p>
+        </div>
+        <div class="status-card">
+          <h2>Container</h2>
+          <p id="container-status" class="status-value">Checking...</p>
+          <p id="container-details" class="status-details"></p>
+        </div>
+      </section>
+      <section class="actions">
+        <button id="pull" class="primary">Pull Image</button>
+        <button id="start" class="primary">Start Container</button>
+        <button id="stop">Stop Container</button>
+        <button id="remove" class="danger">Remove</button>
+      </section>
+      <section id="progress-section" class="progress hidden">
+        <div class="progress-header">
+          <div class="spinner" id="spinner"></div>
+          <h2 id="progress-title">Activity</h2>
+        </div>
+        <pre id="progress-log"></pre>
+      </section>
+      <section id="error-section" class="error hidden"></section>
+      <section id="instructions" class="instructions hidden">
+        <h2>Docker Desktop Required</h2>
+        <p>
+          Docker Desktop must be installed and running to manage the Agent Zero container. Download it from
+          <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noreferrer">docker.com</a> and
+          launch the application before retrying.
+        </p>
+      </section>
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/desktop/src/renderer/index.ts
+++ b/desktop/src/renderer/index.ts
@@ -1,0 +1,251 @@
+import type {
+  DockerContainerInfo,
+  DockerImageInfo,
+  DockerListResult,
+  DockerProgressEvent,
+  DockerRemoveResult,
+  IpcErrorPayload,
+  IpcResponse,
+} from "../common/dockerTypes";
+
+interface OperationState {
+  busy: boolean;
+  label: string;
+}
+
+const imageStatusEl = document.getElementById("image-status") as HTMLParagraphElement;
+const imageDetailsEl = document.getElementById("image-details") as HTMLParagraphElement;
+const containerStatusEl = document.getElementById("container-status") as HTMLParagraphElement;
+const containerDetailsEl = document.getElementById("container-details") as HTMLParagraphElement;
+const progressSection = document.getElementById("progress-section") as HTMLElement;
+const progressLog = document.getElementById("progress-log") as HTMLPreElement;
+const progressTitle = document.getElementById("progress-title") as HTMLHeadingElement;
+const spinner = document.getElementById("spinner") as HTMLElement;
+const errorSection = document.getElementById("error-section") as HTMLElement;
+const instructionsSection = document.getElementById("instructions") as HTMLElement;
+
+const pullButton = document.getElementById("pull") as HTMLButtonElement;
+const startButton = document.getElementById("start") as HTMLButtonElement;
+const stopButton = document.getElementById("stop") as HTMLButtonElement;
+const removeButton = document.getElementById("remove") as HTMLButtonElement;
+const refreshButton = document.getElementById("refresh") as HTMLButtonElement;
+
+let operation: OperationState = { busy: false, label: "" };
+let unsubscribeProgress: (() => void) | null = null;
+
+function setBusy(label: string | null): void {
+  operation = {
+    busy: Boolean(label),
+    label: label ?? "",
+  };
+
+  [pullButton, startButton, stopButton, removeButton, refreshButton].forEach((button) => {
+    button.disabled = operation.busy;
+  });
+
+  if (operation.busy && label) {
+    progressSection.classList.remove("hidden");
+    spinner.classList.remove("hidden");
+    progressTitle.textContent = label;
+  } else {
+    spinner.classList.add("hidden");
+    progressTitle.textContent = "Activity";
+  }
+}
+
+function appendProgress(event: DockerProgressEvent): void {
+  if (event.kind === "success") {
+    progressLog.textContent += `\n✅ ${event.message}`;
+  } else if (event.kind === "error") {
+    progressLog.textContent += `\n⚠️ ${event.message}`;
+  } else {
+    progressLog.textContent += `\n${event.message}`;
+  }
+  progressLog.scrollTop = progressLog.scrollHeight;
+}
+
+function resetProgress(): void {
+  progressLog.textContent = "";
+  progressSection.classList.add("hidden");
+}
+
+function showError(message: string, details?: string, showInstructions = false): void {
+  errorSection.textContent = details ? `${message}\n${details}` : message;
+  errorSection.classList.remove("hidden");
+  if (showInstructions) {
+    instructionsSection.classList.remove("hidden");
+  } else {
+    instructionsSection.classList.add("hidden");
+  }
+}
+
+function clearError(): void {
+  errorSection.classList.add("hidden");
+  errorSection.textContent = "";
+  instructionsSection.classList.add("hidden");
+}
+
+function parseListResult(result: DockerListResult): { image: DockerImageInfo | null; container: DockerContainerInfo | null } {
+  const image = result.images.find((img) => img.repository === "agent0ai/agent-zero" && img.tag === "latest") ?? null;
+  const container =
+    result.containers.find((item) => item.name === "agent-zero" || item.image.startsWith("agent0ai/agent-zero")) ?? null;
+  return { image, container };
+}
+
+function setStatusUnknown(): void {
+  imageStatusEl.textContent = "Unknown";
+  imageDetailsEl.textContent = "Docker status unavailable.";
+  containerStatusEl.textContent = "Unknown";
+  containerDetailsEl.textContent = "Docker status unavailable.";
+  stopButton.disabled = true;
+  startButton.disabled = true;
+  removeButton.disabled = true;
+  pullButton.disabled = true;
+}
+
+function updateStatuses(result: DockerListResult): void {
+  const { image, container } = parseListResult(result);
+
+  if (image) {
+    imageStatusEl.textContent = "Pulled";
+    imageDetailsEl.textContent = `${image.repository}:${image.tag}${image.size ? ` • ${image.size}` : ""}`;
+  } else {
+    imageStatusEl.textContent = "Not Found";
+    imageDetailsEl.textContent = "Pull the docker image to continue.";
+  }
+
+  if (container) {
+    const running = container.state.toLowerCase() === "running";
+    containerStatusEl.textContent = running ? "Running" : "Stopped";
+    const info: string[] = [];
+    if (container.status) {
+      info.push(container.status);
+    }
+    if (container.ports) {
+      info.push(container.ports);
+    }
+    containerDetailsEl.textContent = info.join(" • ");
+    stopButton.disabled = !running || operation.busy;
+    startButton.disabled = running || operation.busy;
+  } else {
+    containerStatusEl.textContent = "Not Created";
+    containerDetailsEl.textContent = "Start the container to launch Agent Zero.";
+    stopButton.disabled = true;
+    startButton.disabled = operation.busy || !image;
+  }
+
+  removeButton.disabled = operation.busy || (!image && !container);
+  pullButton.disabled = operation.busy;
+  refreshButton.disabled = operation.busy;
+}
+
+function handleErrorResponse(error: IpcErrorPayload): void {
+  const isDockerMissing = error.code === "DOCKER_UNAVAILABLE";
+  showError(error.message, error.details, isDockerMissing);
+}
+
+async function invokeAndHandle<T>(
+  action: () => Promise<IpcResponse<T>>,
+  label: string,
+  options?: { resetProgress?: boolean }
+): Promise<IpcResponse<T> | null> {
+  try {
+    if (options?.resetProgress) {
+      resetProgress();
+    }
+    setBusy(label);
+    const response = await action();
+    if (!response.success && response.error) {
+      handleErrorResponse(response.error);
+      return null;
+    }
+    clearError();
+    return response;
+  } catch (error) {
+    showError(error instanceof Error ? error.message : "Unexpected error");
+    return null;
+  } finally {
+    setBusy(null);
+  }
+}
+
+async function refreshStatus(): Promise<void> {
+  const response = await invokeAndHandle(() => window.electronAPI.listDockerResources(), "Refreshing status", {
+    resetProgress: true,
+  });
+  if (response && response.success && response.data) {
+    updateStatuses(response.data);
+  } else {
+    setStatusUnknown();
+  }
+}
+
+async function handlePull(): Promise<void> {
+  resetProgress();
+  clearError();
+  if (!unsubscribeProgress) {
+    unsubscribeProgress = window.electronAPI.onDockerPullProgress((event) => {
+      progressSection.classList.remove("hidden");
+      appendProgress(event);
+    });
+  }
+
+  const response = await invokeAndHandle(() => window.electronAPI.pullDockerImage(), "Pulling docker image");
+  if (response && response.success) {
+    await refreshStatus();
+  }
+}
+
+async function handleStart(): Promise<void> {
+  const response = await invokeAndHandle(() => window.electronAPI.startDockerContainer(), "Starting container");
+  if (response && response.success) {
+    await refreshStatus();
+  }
+}
+
+async function handleStop(): Promise<void> {
+  const response = await invokeAndHandle(() => window.electronAPI.stopDockerContainer(), "Stopping container");
+  if (response && response.success) {
+    await refreshStatus();
+  }
+}
+
+async function handleRemove(): Promise<void> {
+  const response = await invokeAndHandle(() => window.electronAPI.removeDockerResources(), "Removing resources");
+  if (response && response.success) {
+    const data = response.data as DockerRemoveResult | undefined;
+    const summary: string[] = [];
+    if (data?.removedContainer) {
+      summary.push("Container removed");
+    }
+    if (data?.removedImage) {
+      summary.push("Image removed");
+    }
+    if (summary.length) {
+      appendProgress({ kind: "success", message: summary.join(" • ") });
+      progressSection.classList.remove("hidden");
+    }
+    await refreshStatus();
+  }
+}
+
+pullButton.addEventListener("click", () => {
+  void handlePull();
+});
+startButton.addEventListener("click", () => {
+  void handleStart();
+});
+stopButton.addEventListener("click", () => {
+  void handleStop();
+});
+removeButton.addEventListener("click", () => {
+  void handleRemove();
+});
+refreshButton.addEventListener("click", () => {
+  void refreshStatus();
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  resetProgress();
+  void refreshStatus();
+});

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1,0 +1,192 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0b1525;
+  color: #f2f6ff;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #1f355c, #0b1525 55%);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.app {
+  width: min(960px, 100%);
+  background: rgba(12, 20, 35, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 24px 80px rgba(5, 10, 20, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.status-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.status-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.status-card h2 {
+  margin-top: 0;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.status-value {
+  font-size: 24px;
+  margin: 8px 0 4px;
+  font-weight: 600;
+}
+
+.status-details {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+  min-height: 20px;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+button {
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: none;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #2f80ed, #56ccf2);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(47, 128, 237, 0.35);
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f2f6ff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+button.danger {
+  background: linear-gradient(135deg, #eb5757, #ff8a65);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(235, 87, 87, 0.35);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+}
+
+.progress {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px;
+}
+
+.progress-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #56ccf2;
+  animation: spin 1s linear infinite;
+}
+
+.progress pre {
+  margin: 12px 0 0;
+  max-height: 220px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: pre-wrap;
+}
+
+.error {
+  background: rgba(235, 87, 87, 0.18);
+  border: 1px solid rgba(235, 87, 87, 0.65);
+  border-radius: 12px;
+  padding: 16px;
+  color: #ffb3b3;
+  font-size: 15px;
+}
+
+.instructions {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 18px;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.instructions a {
+  color: #56ccf2;
+  font-weight: 600;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "electron"],
+    "lib": ["ES2020", "DOM"],
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Docker service in the Electron main process to pull/start/stop/remove the agent image with robust error handling
- expose IPC handlers and preload bridge for docker operations consumable by the renderer
- implement a renderer dashboard that surfaces container/image status, progress feedback, and Docker Desktop guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2af40a640832ea4936ebf5e41a522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New desktop application with Docker management interface
  * Supports pulling images, starting and stopping containers, and removing resources
  * Real-time progress tracking and live status updates for Docker operations

* **Chores**
  * Project configuration and build setup for desktop application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->