### PR TITLE
Refresh documentation: Docker workflow, MCP/A2A, Projects, prompts & backup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,16 @@
 # Agent Zero Documentation
 To begin with Agent Zero, follow the links below for detailed guides on various topics:
 
+- **[Quick Start](quickstart.md):** Launch Agent Zero fast using Docker and run your first task.
 - **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Agent Zero on your system.
-- **[Usage Guide](usage.md):** Explore GUI features and usage scenarios.
-- **[Development](development.md):** Set up a development environment for Agent Zero.
-- **[Extensibility](extensibility.md):** Learn how to create custom extensions for Agent Zero.
-- **[Connectivity](connectivity.md):** Learn how to connect to Agent Zero from other applications.
+- **[Usage Guide](usage.md):** Explore GUI features, projects, tasks, and workflows.
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
+- **[Extensibility](extensibility.md):** Learn how to create custom extensions, tools, prompts, and projects.
+- **[Connectivity](connectivity.md):** Integrate Agent Zero with external apps, MCP, and A2A.
+- **[MCP Client Setup](mcp_setup.md):** Configure Agent Zero to consume external MCP servers.
+- **[Notifications](notifications.md):** Use the built-in notification system.
+- **[Tunnel](tunnel.md):** Expose your instance via a secure tunnel.
+- **[Development](development.md):** Set up a development environment for Agent Zero.
 - **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
 
@@ -23,6 +27,9 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
 - [Welcome to the Agent Zero Documentation](#agent-zero-documentation)
   - [Your Experience with Agent Zero](#your-experience-with-agent-zero-starts-now)
   - [Table of Contents](#table-of-contents)
+- [Quick Start Guide](quickstart.md)
+  - [Launching the Web UI](quickstart.md#launching-the-web-ui)
+  - [Running a Simple Task](quickstart.md#running-a-simple-task)
 - [Installation Guide](installation.md)
   - [Windows, macOS and Linux Setup](installation.md#windows-macos-and-linux-setup-guide)
   - [Settings Configuration](installation.md#settings-configuration)
@@ -30,7 +37,6 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
   - [Installing and Using Ollama](installation.md#installing-and-using-ollama-local-models)
   - [Using Agent Zero on Mobile](installation.md#using-agent-zero-on-your-mobile-device)
   - [How to Update Agent Zero](installation.md#how-to-update-agent-zero)
-  - [Full Binaries Installation](installation.md#in-depth-guide-for-full-binaries-installation)
 - [Usage Guide](usage.md)
   - [Basic Operations](usage.md#basic-operations)
     - [Restart Framework](usage.md#restart-framework)
@@ -40,6 +46,10 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
   - [Example of Tools Usage](usage.md#example-of-tools-usage-web-search-and-code-execution)
   - [Multi-Agent Cooperation](usage.md#multi-agent-cooperation)
   - [Prompt Engineering](usage.md#prompt-engineering)
+  - [Projects](usage.md#projects)
+  - [Tasks and Scheduling](usage.md#tasks-and-scheduling)
+  - [Notifications](usage.md#notifications)
+  - [Browser Agent Status](usage.md#browser-agent-status)
   - [Voice Interface](usage.md#voice-interface)
   - [Mathematical Expressions](usage.md#mathematical-expressions)
   - [File Browser](usage.md#file-browser)
@@ -53,16 +63,26 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
     - [Tools](architecture.md#2-tools)
     - [SearXNG Integration](architecture.md#searxng-integration)
     - [Memory System](architecture.md#3-memory-system)
-    - [Messages History and Summarization](archicture.md#messages-history-and-summarization)
+    - [Messages History and Summarization](architecture.md#messages-history-and-summarization)
     - [Prompts](architecture.md#4-prompts)
     - [Knowledge](architecture.md#5-knowledge)
     - [Instruments](architecture.md#6-instruments)
     - [Extensions](architecture.md#7-extensions)
-  - [Contributing](contribution.md)
-  - [Getting Started](contribution.md#getting-started)
-  - [Making Changes](contribution.md#making-changes)
-  - [Submitting a Pull Request](contribution.md#submitting-a-pull-request)
-  - [Documentation Stack](contribution.md#documentation-stack)
+- [Extensibility](extensibility.md)
+  - [Extensions](extensibility.md#extensions)
+  - [Tools](extensibility.md#tools)
+  - [Prompts](extensibility.md#prompts)
+  - [Subagent Customization](extensibility.md#subagent-customization)
+  - [Projects](extensibility.md#projects)
+- [Connectivity](connectivity.md)
+  - [External API Endpoints](connectivity.md#external-api-endpoints)
+  - [MCP Server Connectivity](connectivity.md#mcp-server-connectivity)
+  - [A2A (Agent-to-Agent) Connectivity](connectivity.md#a2a-agent-to-agent-connectivity)
+- [MCP Client Setup](mcp_setup.md)
+- [Notifications](notifications.md)
+- [Tunnel](tunnel.md)
+- [Development](development.md)
+- [Contributing](contribution.md)
 - [Troubleshooting and FAQ](troubleshooting.md)
   - [Frequently Asked Questions](troubleshooting.md#frequently-asked-questions)
   - [Troubleshooting](troubleshooting.md#troubleshooting)

--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -538,6 +538,14 @@ attachmentWorkflow();
 
 ---
 
+## MCP Client Connectivity
+
+Agent Zero can consume external MCP servers (stdio, SSE, or streaming HTTP). Configure MCP clients in **Settings → External Services → MCP Client**.
+
+See [MCP Client Setup](mcp_setup.md) for configuration formats, examples, and recommended MCP servers.
+
+---
+
 ## MCP Server Connectivity
 
 Agent Zero includes an MCP Server that allows other MCP-compatible clients to connect to it. The server runs on the same URL and port as the Web UI.
@@ -583,3 +591,6 @@ To connect another agent to your Agent Zero instance, use the following URL form
 ```
 YOUR_AGENT_ZERO_URL/a2a/t-YOUR_API_TOKEN
 ```
+
+> [!TIP]
+> A2A is useful when you want two isolated Agent Zero instances (or other FastA2A agents) to collaborate while keeping separate contexts.

--- a/docs/development.md
+++ b/docs/development.md
@@ -132,6 +132,9 @@ My Dockerized instance:
 My VS Code instance:
 ![VS Code instance](res/dev/devinst-13.png)
 
+## RFC Notes (Windows & Host Execution)
+Agent Zero runs code inside the container by default. If you need to execute code **directly on your Windows host**, configure RFC in Settings → Development and point it to a running Agent Zero container. This routes code execution through SSH/RFC to the container while keeping the UI and agent loop on your host IDE.
+
 
 # 🎉 Congratulations! 🚀
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -99,6 +99,9 @@ When a tool is called, it goes through the following lifecycle:
 3. `execute` method (main functionality)
 4. `after_execution` method
 
+> [!TIP]
+> Prefer **Instruments** for reusable scripts that should not bloat the system prompt. Tools are always present in the prompt; instruments are recalled on demand.
+
 ### API Endpoints
 API endpoints expose Agent Zero functionality to external systems or the user interface. They are modular and can be extended or replaced.
 
@@ -119,6 +122,9 @@ Prompts define the instructions and context provided to the LLM. They are highly
 Prompts are located in:
 - Default prompts: `/prompts/`
 - Agent-specific prompts: `/agents/{agent_profile}/prompts/`
+
+> [!IMPORTANT]
+> Custom prompt overrides now live in `/agents/<agent_profile>/prompts/`. Only add the files you want to override; everything else is loaded from `/prompts/`.
 
 #### Prompt Features
 Agent Zero's prompt system supports several powerful features:
@@ -205,6 +211,9 @@ This example overrides the default role definition in `/prompts/agent.system.mai
 
 ## Subagent Customization
 Agent Zero supports creating specialized subagents with customized behavior. The `_example` agent in the `/agents/_example/` directory demonstrates this pattern.
+
+> [!NOTE]
+> The `hacker` profile ships with the default Docker image. You can select it in **Settings → Agent Config**.
 
 ### Creating a Subagent
 
@@ -293,6 +302,9 @@ Projects are the recommended way to create specialized workflows in Agent Zero w
 - Isolate file context, knowledge, and memory for a particular task or client
 - Keep passwords and other secrets scoped to a single workspace
 - Run multiple independent flows side by side under the same Agent Zero installation
+
+> [!TIP]
+> Projects pair well with the Task Scheduler. You can schedule tasks inside a project to keep context and memory isolated while still automating recurring work.
 
 ## Best Practices
 - Keep extensions focused on a single responsibility

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ Click to open a video to learn how to install Agent Zero:
 
 [![Easy Installation guide](/docs/res/easy_ins_vid.png)](https://www.youtube.com/watch?v=w5v5Kjx51hs)
 
-The following user guide provides instructions for installing and running Agent Zero using Docker, which is the primary runtime environment for the framework. For developers and contributors, we also provide instructions for setting up the [full development environment](#in-depth-guide-for-full-binaries-installation).
+The following user guide provides instructions for installing and running Agent Zero using Docker, which is the primary runtime environment for the framework. For developers and contributors, follow the [development guide](development.md) to set up a hybrid local + Docker workflow.
 
 
 ## Windows, macOS and Linux Setup Guide
@@ -58,7 +58,7 @@ The following user guide provides instructions for installing and running Agent 
 
 2. **Run Agent Zero:**
 
-- Note: Agent Zero also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
+- Note: The Hacker Edition profile is included in the main Docker image. After first launch, select the `hacker` profile in **Settings → Agent Config → Default agent profile**.
 
 2.1. Pull the Agent Zero Docker image:
 - Search for `agent0ai/agent-zero` in Docker Desktop
@@ -74,27 +74,19 @@ The following user guide provides instructions for installing and running Agent 
 > docker pull agent0ai/agent-zero
 > ```
 
-2.2. OPTIONAL - Create a data directory for persistence:
+2.2. OPTIONAL - Create a host folder for working files:
 
 > [!CAUTION]
-> Preferred way of persisting Agent Zero data is to use the backup and restore feature.
-> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
+> The recommended way to persist Agent Zero data across upgrades is **Backup & Restore** in the Settings UI.
+> Do **not** map the entire `/a0` directory. It contains the application code and will cause upgrade conflicts.
 
-- Choose or create a directory on your machine where you want to store Agent Zero's data
-- This can be any location you prefer (e.g., `C:/agent-zero-data` or `/home/user/agent-zero-data`)
-- You can map individual subfolders of `/a0` to a local directory or the full `/a0` directory (not recommended).
-- This directory will contain all your Agent Zero files, like the legacy root folder structure:
-  - `/agents` - Specialized agents with their prompts and tools
-  - `/memory` - Agent's memory and learned information
-  - `/knowledge` - Knowledge base
-  - `/instruments` - Instruments and functions
-  - `/prompts` - Prompt files
-  - `.env` - Your API keys
-  - `/tmp/settings.json` - Your Agent Zero settings
+- If you want the agent to work with files from your host machine without attaching them, map **one specific folder**.
+- Examples:
+  - Map a working folder: `-v /path/to/your/data:/root/data`
+  - Map project files: `-v /path/to/your/projects:/a0/usr/projects`
 
 > [!TIP]
-> Choose a location that's easy to access and backup. All your Agent Zero data 
-> will be directly accessible in this directory.
+> Keep host mappings narrow and purpose-driven. Use Backup & Restore for settings, memories, and knowledge.
 
 2.3. Run the container:
 - In Docker Desktop, go back to the "Images" tab
@@ -102,13 +94,16 @@ The following user guide provides instructions for installing and running Agent 
 - Open the "Optional settings" menu
 - Set the web port (80) to desired host port number in the second "Host port" field or set to `0` for automatic port assignment
 
+> [!IMPORTANT]
+> The Web UI is served on container port **80**. You must map at least one host port to container port 80 (or set host to `0` for a random port) to access the UI.
+
 Optionally you can map local folders for file persistence:
 > [!CAUTION]
 > Preferred way of persisting Agent Zero data is to use the backup and restore feature.
 > By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
 - OPTIONAL: Under "Volumes", configure your mapped folders, if needed:
-  - Example host path: Your chosen directory (e.g., `C:\agent-zero\memory`)
-  - Example container path: `/a0/memory`
+  - Example host path: Your chosen directory (e.g., `C:\agent-zero-data`)
+  - Example container path: `/root/data` or `/a0/usr/projects`
 
 
 - Click the `Run` button in the "Images" tab.
@@ -123,7 +118,7 @@ Optionally you can map local folders for file persistence:
 > [!TIP]
 > Alternatively, run the following command in your terminal:
 > ```bash
-> docker run -p $PORT:80 -v /path/to/your/data:/a0 agent0ai/agent-zero
+> docker run -p $PORT:80 -v /path/to/your/data:/root/data agent0ai/agent-zero
 > ```
 > - Replace `$PORT` with the port you want to use (e.g., `50080`)
 > - Replace `/path/to/your/data` with your chosen directory path
@@ -143,9 +138,7 @@ Optionally you can map local folders for file persistence:
 > You can also access the Web UI by clicking the ports right under the container ID in Docker Desktop.
 
 > [!NOTE]
-> After starting the container, you'll find all Agent Zero files in your chosen 
-> directory. You can access and edit these files directly on your machine, and 
-> the changes will be immediately reflected in the running container.
+> If you mapped a host folder (for example `/root/data` or `/a0/usr/projects`), you can access and edit those files directly on your machine. Changes are reflected immediately inside the running container.
 
 3. Configure Agent Zero
 - Refer to the following sections for a full guide on how to configure Agent Zero.
@@ -154,9 +147,12 @@ Optionally you can map local folders for file persistence:
 Agent Zero provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
 
 ### Agent Configuration
-- **Prompts Subdirectory:** Choose the subdirectory within `/prompts` for agent behavior customization. The 'default' directory contains the standard prompts.
+- **Default Agent Profile:** Select which profile under `/agents` the main agent should use (e.g., `agent0`, `hacker`, `researcher`).
 - **Memory Subdirectory:** Select the subdirectory for agent memory storage, allowing separation between different instances.
 - **Knowledge Subdirectory:** Specify the location of custom knowledge files to enhance the agent's understanding.
+
+> [!TIP]
+> Custom prompt overrides live in `/a0/agents/<agent_profile>/prompts/`. Place only the files you want to override; everything else falls back to the defaults in `/a0/prompts/`.
 
 ![settings](res/setup/settings/1-agentConfig.png)
 
@@ -176,6 +172,8 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 ### Embedding Model Settings
 - **Provider:** Choose the embedding model provider (e.g., OpenAI)
 - **Model Name:** Select the specific embedding model (e.g., text-embedding-3-small)
+> [!NOTE]
+> Agent Zero defaults to a small local embedding model. You can swap to OpenAI (`text-embedding-3-small` or `text-embedding-3-large`) if you prefer.
 
 ### Speech to Text Options
 - **Model Size:** Choose the speech recognition model size
@@ -185,6 +183,12 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 ### API Keys
 - Configure API keys for various service providers directly within the Web UI
 - Click `Save` to confirm your settings
+
+> [!TIP]
+> For OpenAI-compatible providers (including custom endpoints), add the key under **External Services → Other OpenAI Compatible API keys** and then select **OpenAI Compatible** as the provider for your model.
+
+> [!NOTE]
+> OpenAI Plus subscriptions do **not** include API credits. You must use an API key from the OpenAI API dashboard.
 
 > [!CAUTION]
 > **GitHub Copilot Provider:** When using the GitHub Copilot provider, after selecting the model and entering your first prompt, the OAuth login procedure will begin. You'll find the authentication code and link in the output logs. Complete the authentication process by following the provided link and entering the code, then you may continue using Agent Zero.
@@ -204,7 +208,7 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 ### Development Settings
 - **RFC Parameters (local instances only):** configure URLs and ports for remote function calls between instances
 - **RFC Password:** Configure password for remote function calls
-Learn more about Remote Function Calls and their purpose [here](#7-configure-agent-zero-rfc).
+Learn more about Remote Function Calls (RFC) in the [development guide](development.md).
 
 > [!IMPORTANT]
 > Always keep your API keys and passwords secure.
@@ -224,6 +228,28 @@ The Settings page is the control center for selecting the Large Language Models 
 3. Click "Save" to apply the changes.
 
 ## Important Considerations
+
+### Model Naming by Provider
+Make sure the model name matches the selected provider. A common error is using an OpenRouter-prefixed model name with a native provider.
+
+| Provider | Model Name Format | Example |
+| --- | --- | --- |
+| OpenAI | Model name only | `gpt-4.1` |
+| OpenRouter | Provider prefix required | `openai/gpt-4.1` |
+| Venice | Model name only (supports inline params) | `qwen3-235b:disable_thinking=true` |
+| Ollama | Model name only | `llama3.2` |
+
+> [!IMPORTANT]
+> Remove `openai/` from the model name when using the **OpenAI** provider. That prefix is for **OpenRouter** only.
+
+### Utility Model Sizing
+Utility models handle memory extraction and summarization. Very small models (e.g., 4B) are **not** reliable for memory extraction. Use a strong utility model (70B+ recommended) or a high-quality hosted model like Gemini Flash, GPT mini, or Grok Fast.
+
+### Context Window Tuning
+Set the **total context length** first (e.g., 100k), then adjust **Context Window Space** for how much of that should be reserved for chat history. The remaining space is used for system prompts, RAG, and responses. If you set a huge context window, even small proportions can still be massive (e.g., 0.3 of 1M = 300k).
+
+### Reasoning / Thinking Models
+Some reasoning models are slower and can overthink. If responses feel slow or get worse, try disabling reasoning or switching to a non-thinking variant.
 
 ## Installing and Using Ollama (Local Models)
 If you're interested in Ollama, which is a powerful tool that allows you to run various large language models locally, here's how to install and use it:
@@ -247,7 +273,7 @@ curl -fsSL https://ollama.com/install.sh | sh
 ```
 
 **Finding Model Names:**
-Visit the [Ollama model library](https://ollama.com/library) for a list of available models and their corresponding names.  The format is usually `provider/model-name` (or just `model-name` in some cases).
+Visit the [Ollama model library](https://ollama.com/library) for a list of available models and their corresponding names. Use the model name exactly as listed (e.g., `llama3.2`, `qwen2.5:7b`).
 
 #### Second step: pulling the model
 **On Windows, macOS, and Linux:**
@@ -266,7 +292,9 @@ ollama pull <model-name>
 
 3. Write your model code as expected by Ollama, in the format `llama3.2` or `qwen2.5:7b`
 
-4. Provide your API base URL to your ollama API endpoint, usually `http://host.docker.internal:11434`
+4. Provide your API base URL to your Ollama API endpoint, usually `http://host.docker.internal:11434`
+   - If Ollama runs in another Docker container, put both containers on the same Docker network and use `http://<container_name>:11434`
+   - If Ollama runs on your host, ensure port **11434** is reachable from the Agent Zero container
 
 5. Click `Save` to confirm your settings.
 
@@ -293,7 +321,7 @@ Once you've downloaded some models, you might want to check which ones you have 
 Agent Zero's Web UI is accessible from any device on your network through the Docker container:
 
 > [!NOTE]
-> In settings, External Services tab, you can enable Cloudflare Tunnel to expose your Agent Zero instance to the internet.
+> In settings, External Services tab, you can enable Cloudflare Tunnel to expose your Agent Zero instance to the internet. See the [Tunnel guide](tunnel.md) for details.
 > ⚠️ Do not forget to set username and password in the settings Authentication tab to secure your instance on the internet.
 
 1. The Docker container automatically exposes the Web UI on all network interfaces
@@ -313,68 +341,43 @@ Agent Zero's Web UI is accessible from any device on your network through the Do
 > If you're running Agent Zero directly on your system (legacy approach) instead of 
 > using Docker, you'll need to configure the host manually in `run_ui.py` to run on all interfaces using `host="0.0.0.0"`.
 
-For developers or users who need to run Agent Zero directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
+For developers who need to run Agent Zero directly on their system, see the [development guide](development.md).
 
 # How to update Agent Zero
 
 > [!NOTE]
-> Since v0.9, Agent Zero has a Backup and Restore feature, so you don't need to backup the files manually.
-> In Settings, Backup and Restore tab will guide you through the process.
+> The safest upgrade path is to use **Backup & Restore** in the Settings UI.
+> Avoid mapping the entire `/a0` directory when upgrading.
 
-1. **If you come from the previous version of Agent Zero:**
-- Your data is safely stored across various directories and files inside the Agent Zero folder.
-- To update to the new Docker runtime version, you might want to backup the following files and directories:
-  - `/memory` - Agent's memory
-  - `/knowledge` - Custom knowledge base (if you imported any custom knowledge files)
-  - `/instruments` - Custom instruments and functions (if you created any custom)
-  - `/tmp/settings.json` - Your Agent Zero settings
-  - `/tmp/chats/` - Your chat history
-- Once you have saved these files and directories, you can proceed with the Docker runtime [installation instructions above](#windows-macos-and-linux-setup-guide) setup guide.
-- Reach for the folder where you saved your data and copy it to the new Agent Zero folder set during the installation process.
-- Agent Zero will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
+## Recommended update flow (Docker Desktop or Docker CLI)
 
-> [!IMPORTANT]
-> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Agent Zero generate a new one.
-> The same goes for chats in `/tmp/chats/`, they might be incompatible with the new version
-
-2. **Update Process (Docker Desktop)**
-- Go to Docker Desktop and stop the container from the "Containers" tab
-- Right-click and select "Remove" to remove the container
-- Go to "Images" tab and remove the `agent0ai/agent-zero` image or click the three dots to pull the difference and update the Docker image.
-
-![docker delete image](res/setup/docker-delete-image-1.png)
-
-- Search and pull the new image if you chose to remove it
-- Run the new container with the same volume settings as the old one
-
-> [!IMPORTANT]
-> Make sure to use the same volume mount path when running the new
-> container to preserve your data. The exact path depends on where you stored
-> your Agent Zero data directory (the chosen directory on your machine).
+1. **Create a backup** on your current instance: **Settings → Backup & Restore**.
+2. **Start a new container** with the latest image (keep the old container running until restore succeeds).
+3. **Restore the backup** in the new instance.
+4. **Copy secrets manually (if needed):**
+   - Secrets are stored in `/a0/tmp/secrets.env`.
+   - If secrets are missing after restore, copy this file to the new container.
 
 > [!TIP]
-> Alternatively, run the following commands in your terminal:
->
-> ```bash
-> # Stop the current container
-> docker stop agent-zero
->
-> # Remove the container (data is safe in the folder)
-> docker rm agent-zero
->
-> # Remove the old image
-> docker rmi agent0ai/agent-zero
->
-> # Pull the latest image
-> docker pull agent0ai/agent-zero
->
-> # Run new container with the same volume mount
-> docker run -p $PORT:80 -v /path/to/your/data:/a0 agent0ai/agent-zero
-> ```
+> Chat history is stored in `/a0/tmp/chats/`. If you need manual access for audits, that is the location.
+
+## CLI update example (Linux/VPS)
+
+```bash
+export IMAGE="agent0ai/agent-zero:latest"
+
+# Stop containers based on the image
+docker ps -a -q --filter ancestor=$IMAGE | xargs -r docker stop
+
+# Remove stopped containers
+docker ps -a -q --filter ancestor=$IMAGE | xargs -r docker rm
+
+# Pull latest image
+docker pull $IMAGE
+```
 
       
 ### Conclusion
 After following the instructions for your specific operating system, you should have Agent Zero successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
 
 If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.
-

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -2,6 +2,9 @@
 
 This guide explains how to configure and utilize external tool providers through the Model Context Protocol (MCP) with Agent Zero. This allows Agent Zero to leverage tools hosted by separate local or remote MCP-compliant servers.
 
+> [!NOTE]
+> Agent Zero can act as both an MCP **client** (this guide) and an MCP **server**. For server setup, see [Connectivity](connectivity.md#mcp-server-connectivity).
+
 ## What are MCP Servers?
 
 MCP servers are external processes or services that expose a set of tools that Agent Zero can use. Agent Zero acts as an MCP *client*, consuming tools made available by these servers. The integration supports three main types of MCP servers:
@@ -144,3 +147,14 @@ Once configured, successfully installed (if applicable, e.g., for `npx` based se
 *   **Execution Flow**: Agent Zero's `process_tools` method (with logic in `python/helpers/mcp_handler.py`) prioritizes looking up the tool name in the `MCPConfig`. If found, the execution is delegated to the corresponding MCP server. If not found as an MCP tool, it then attempts to find a local/built-in tool with that name.
 
 This setup provides a flexible way to extend Agent Zero's capabilities by integrating with various external tool providers without modifying its core codebase.
+
+## Recommended MCP Servers
+
+Community-tested MCP options include:
+- **BrowserOS MCP** (browser automation)
+- **Chrome DevTools MCP** (browser automation)
+- **Playwright MCP** (browser automation)
+- **n8n MCP integrations** (workflow automation)
+
+> [!TIP]
+> If Agent Zero is running in Docker, remote MCP servers (SSE or streaming HTTP) are often easier than stdio servers running on the host.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,39 +1,42 @@
 # Quick Start
 This guide provides a quick introduction to using Agent Zero. We'll cover launching the web UI, starting a new chat, and running a simple task.
 
-## Launching the Web UI
-1. Make sure you have Agent Zero installed and your environment set up correctly (refer to the [Installation guide](installation.md) if needed).
-2. Open a terminal in the Agent Zero directory and activate your conda environment (if you're using one).
-3. Run the following command:
+## Launching the Web UI (Docker)
+1. Pull the latest image:
 
 ```bash
-python run_ui.py
+docker pull agent0ai/agent-zero:latest
 ```
 
-4.  A message similar to this will appear in your terminal, indicating the Web UI is running:
+2. Run the container and let Docker assign a port:
 
-![](res/flask_link.png)
+```bash
+docker run -p 0:80 agent0ai/agent-zero:latest
+```
 
-5. Open your web browser and navigate to the URL shown in the terminal (usually `http://127.0.0.1:50001`). You should see the Agent Zero Web UI.
+3. Find the mapped port:
+   - **Docker Desktop**: look under the container for `<PORT>:80`
+   - **CLI**: run `docker ps` and check the Ports column
 
-![New Chat](res/ui_newchat1.png)
+4. Open the Web UI in your browser:
+
+```
+http://localhost:<PORT>
+```
+
+5. Open **Settings** and configure your API keys and models.
 
 > [!TIP]
-> As you can see, the Web UI has four distinct buttons for easy chat management: 
-> `New Chat`, `Reset Chat`, `Save Chat`, and `Load Chat`.
-> Chats can be saved and loaded individually in `json` format and are stored in the
-> `/tmp/chats` directory.
+> If you are developing locally (not Docker), use `python run_ui.py` instead and follow the [development guide](development.md).
 
-    ![Chat Management](res/ui_chat_management.png)
+![New Chat](res/ui_newchat1.png)
 
 ## Running a Simple Task
 Let's ask Agent Zero to download a YouTube video. Here's how:
 
-1.  Type "Download a YouTube video for me" in the chat input field and press Enter or click the send button.
-
-2. Agent Zero will process your request.  You'll see its "thoughts" and the actions it takes displayed in the UI. It will find a default already existing solution, that implies using the `code_execution_tool` to run a simple Python script to perform the task.
-
-3. The agent will then ask you for the URL of the YouTube video you want to download.
+1. Type "Download a YouTube video for me" in the chat input field and press Enter or click the send button.
+2. Agent Zero will process your request. You'll see its thought process and tool calls in the UI.
+3. The agent will ask you for the URL of the YouTube video you want to download.
 
 ## Example Interaction
 Here's an example of what you might see in the Web UI at step 3:
@@ -49,6 +52,8 @@ Now that you've run a simple task, you can experiment with more complex requests
 * Create or modify files
 
 > [!TIP]
-> The [Usage Guide](usage.md) provides more in-depth information on using Agent 
-> Zero's various features, including prompt engineering, tool usage, and multi-agent 
-> cooperation.
+> The [Usage Guide](usage.md) provides more in-depth information on using Agent
+> Zero's various features, including prompt engineering, tool usage, projects, and scheduling.
+
+> [!NOTE]
+> Chat history is stored in `/a0/tmp/chats/` inside the container.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,36 +8,50 @@ This page addresses frequently asked questions (FAQ) and provides troubleshootin
 **2. When I input something in the chat, nothing happens. What's wrong?**
 -   Check if you have set up API keys in the Settings page. If not, the application will not be able to communicate with the endpoints it needs to run LLMs and to perform tasks.
 
-**3. How do I integrate open-source models with Agent Zero?**
-Refer to the [Choosing your LLMs](installation.md#installing-and-using-ollama-local-models) section of the documentation for detailed instructions and examples for configuring different LLMs. Local models can be run using Ollama or LM Studio.
+**3. I get “invalid model ID.” What does that mean?**
+-   You likely selected the wrong provider for the model name. For example, `openai/gpt-4.1` only works with **OpenRouter**. For native OpenAI, use `gpt-4.1`.
+
+**4. Does OpenAI Plus include API credits?**
+-   No. You need a paid OpenAI API key from the API dashboard.
+
+**5. How do I integrate open-source models with Agent Zero?**
+Refer to the [Ollama setup](installation.md#installing-and-using-ollama-local-models) section for local models. Ensure port **11434** is reachable from the container.
 
 > [!TIP]
 > Some LLM providers offer free usage of their APIs, for example Groq, Mistral, SambaNova or CometAPI.
 
-**6. How can I make Agent Zero retain memory between sessions?**
-Refer to the [How to update Agent Zero](installation.md#how-to-update-agent-zero) section of the documentation for instructions on how to update Agent Zero while retaining memory and data.
+**6. Why can’t I access the Web UI?**
+-   Ensure you mapped at least one host port to container port **80** (or used host port `0` for an auto-assigned port).
 
-**7. Where can I find more documentation or tutorials?**
--   Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for support and discussions.
+**7. How can I make Agent Zero retain memory between sessions?**
+-   Use **Backup & Restore** in Settings. Avoid mapping the entire `/a0` directory.
 
-**8. How do I adjust API rate limits?**
+**8. Where is chat history stored?**
+-   Chat history lives in `/a0/tmp/chats/`.
+
+**9. My secrets disappeared after restore.**
+-   Secrets are stored in `/a0/tmp/secrets.env`. Copy this file manually after restoring.
+
+**10. The browser agent fails or is unstable.**
+-   The built-in browser agent can have dependency issues. Use MCP browser servers (BrowserOS, Chrome DevTools, Playwright) instead.
+
+**11. How do I adjust API rate limits?**
 Modify the `rate_limit_seconds` and `rate_limit_requests` parameters in the `AgentConfig` class within `initialize.py`.
 
-**9. My code_execution_tool doesn't work, what's wrong?**
--   Ensure you have Docker installed and running.  If using Docker Desktop on macOS, grant it access to your project files in Docker Desktop's settings.  Check the [Installation guide](installation.md#4-install-docker-docker-desktop-application) for more details.
--   Verify that the Docker image is updated.
-
-**10. Can Agent Zero interact with external APIs or services (e.g., WhatsApp)?**
+**12. Can Agent Zero interact with external APIs or services (e.g., WhatsApp)?**
 Extending Agent Zero to interact with external APIs is possible by creating custom tools or solutions. Refer to the documentation on creating them. 
 
 ## Troubleshooting
 
 **Installation**
-- **Docker Issues:** If Docker containers fail to start, consult the Docker documentation and verify your Docker installation and configuration.  On macOS, ensure you've granted Docker access to your project files in Docker Desktop's settings as described in the [Installation guide](installation.md#4-install-docker-docker-desktop-application). Verify that the Docker image is updated.
+- **Docker Issues:** If Docker containers fail to start, consult the Docker documentation and verify your Docker installation and configuration. On macOS, ensure you've granted Docker access to your project files in Docker Desktop's settings as described in the [Installation guide](installation.md#windows-macos-and-linux-setup-guide). Verify that the Docker image is updated.
+- **Ollama Connectivity:** If local models are unreachable, confirm port **11434** is accessible from the container (`http://host.docker.internal:11434` or `http://<container_name>:11434` on a shared Docker network).
 
 **Usage**
 
 - **Terminal commands not executing:** Ensure the Docker container is running and properly configured.  Check SSH settings if applicable. Check if the Docker image is updated by removing it from Docker Desktop app, and subsequently pulling it again.
+- **Context window errors:** Reduce the total context window size or lower the chat history allocation to avoid oversized prompts.
+- **Temperature parameter errors:** If you set `temperature=0` as an extra parameter and see errors, remove it from model settings and retry.
 
 * **Error Messages:** Pay close attention to the error messages displayed in the Web UI or terminal.  They often provide valuable clues for diagnosing the issue. Refer to the specific error message in online searches or community forums for potential solutions.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,7 @@ Agent Zero supports direct file attachments in the chat interface for seamless f
 Agent Zero's power comes from its ability to use [tools](architecture.md#tools). Here's how to leverage them effectively:
 
 - **Understand Tools:** Agent Zero includes default tools like knowledge (powered by SearXNG), code execution, and communication. Understand the capabilities of these tools and how to invoke them.
+- **MCP Tools:** Once configured, MCP tools appear alongside built-in tools and can be called by name. See [MCP Client Setup](mcp_setup.md).
 
 ## Example of Tools Usage: Web Search and Code Execution
 Let's say you want Agent Zero to perform some financial analysis tasks. Here's a possible prompt:
@@ -136,6 +137,55 @@ Effective prompt engineering is crucial for getting the most out of Agent Zero. 
 * **Provide Context:** If necessary, provide background information or context to help the agent understand the task better. This might include relevant details, constraints, or desired format for the response.
 * **Break Down Complex Tasks:**  For complex tasks, break them down into smaller, more manageable sub-tasks.  This makes it easier for the agent to reason through the problem and generate a solution.
 * **Iterative Refinement:** Don't expect perfect results on the first try.  Experiment with different prompts, refine your instructions based on the agent's responses, and iterate until you achieve the desired outcome. To achieve a full-stack, web-app development task, for example, you might need to iterate for a few hours for 100% success.
+
+## Projects
+Projects provide isolated workspaces with their own instructions, memory, knowledge, secrets, and files. They are ideal for separating clients, long-running tasks, or separate research tracks.
+
+**What Projects give you:**
+- Context separation across chats and agents
+- Project-specific memory and knowledge imports
+- Project-scoped secrets and variables
+- A dedicated project folder for files
+
+> [!TIP]
+> Projects pair especially well with Tasks and Notifications. You can schedule tasks to run inside a project and get notified when they finish.
+
+See [Projects](extensibility.md#projects) for structure details and the project folder layout.
+
+## Secrets and Variables
+Use secrets for sensitive values (API keys, passwords) and variables for non-sensitive settings. The agent can reference these values by alias in prompts.
+
+- **Global secrets:** stored in `/a0/tmp/secrets.env`
+- **Project secrets:** stored in `/a0/usr/projects/<project>/.a0proj/secrets.env`
+
+> [!TIP]
+> For login automation, store credentials in secrets and instruct the agent to select the matching alias when prompted.
+
+## Tasks and Scheduling
+Agent Zero includes a built-in task scheduler. You can create tasks in two ways:
+
+- **Via UI:** Settings → Tasks Scheduler (schedule a task and choose a target agent/profile).
+- **Via prompts:** Ask the agent to schedule a task for a future time.
+
+Tasks can automatically open a chat at the scheduled time and run with dedicated context. This is particularly powerful when combined with Projects (project-specific context) and Notifications (status updates).
+
+## Notifications
+Agent Zero can display real-time notifications for task progress, errors, and system events.
+
+- Use notifications to track long-running tasks.
+- Combine with scheduled tasks to get “done” alerts without keeping a tab open.
+
+See the [Notifications guide](notifications.md) for code-level and UI usage.
+
+## Browser Agent Status
+The built-in browser agent currently has dependency issues on some systems. If you encounter failures, use MCP browser servers instead.
+
+Recommended alternatives:
+- **BrowserOS MCP**
+- **Chrome DevTools MCP**
+- **Playwright MCP**
+
+See [MCP Client Setup](mcp_setup.md) for configuration details.
 
 ## Voice Interface
 Agent Zero provides both Text-to-Speech (TTS) and Speech-to-Text (STT) capabilities for natural voice interaction:
@@ -190,6 +240,7 @@ Configure STT settings in the Settings page:
 > enhances user privacy while maintaining functionality.
 
 
+## Mathematical Expressions
 * **Complex Mathematics:** Supports full KaTeX syntax for:
   - Fractions, exponents, and roots
   - Matrices and arrays
@@ -330,6 +381,9 @@ Optionally clean up existing files before restoring:
 * **API Keys**: Backups include your API keys and sensitive configuration
 * **Secure Storage**: Store backup files securely and don't share them
 * **Clean Systems**: When restoring on new systems, verify all configurations
+
+> [!IMPORTANT]
+> Secrets are stored in `/a0/tmp/secrets.env`. If secrets are missing after a restore, copy this file manually.
 
 ### Common Use Cases
 


### PR DESCRIPTION
### Motivation
- Align documentation with the current Docker-first workflow and community best-practices (port mapping, avoid mapping `/a0`, and prefer Backup & Restore). 
- Prevent common configuration errors by correcting model/provider naming, context-window guidance, and utility model sizing recommendations. 
- Add missing, verified coverage for new features and integrations such as MCP (client/server), A2A, Projects, Tasks, Instruments, and RFC usage. 
- Improve discoverability and machine-readable quality by adding cross-links and explicit locations for secrets and chat history.

### Description
- Updated `docs/README.md` and the following major guides: `installation.md`, `quickstart.md`, `usage.md`, `architecture.md`, `extensibility.md`, `connectivity.md`, `mcp_setup.md`, `development.md`, and `troubleshooting.md` to reflect current behavior and add navigation links. 
- Rewrote installation/quickstart to emphasize a Docker-first flow, require at least one host port mapped to container port `80` (or use `0` for random assignment), and recommend `Backup & Restore` instead of mounting the entire `/a0` volume. 
- Clarified model configuration rules (provider-specific naming and removing the `openai/` prefix for native OpenAI), context window tuning guidance, and utility-model sizing advice (noting 70B+ for reliable memory extraction), and added Ollama networking tips. 
- Added practical guidance and examples for MCP client configuration and recommended MCP servers (BrowserOS, Chrome DevTools, Playwright, n8n), A2A usage tips, Projects/Tasks/Notifications workflows, secrets locations (`/a0/tmp/secrets.env`) and prompt override location (`/agents/<agent_profile>/prompts/`), and included RFC notes in `development.md`.

### Testing
- No automated tests were run because this is a documentation-only change; CI/automation may still validate markdown and links during the repository's normal checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df404c000832ea80665d4934a4392)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes and cross-links the docs to reflect current behavior and reduce setup errors.
> 
> - Emphasizes a Docker-first install/quickstart: map host port to container `80`, avoid mapping `/a0`, prefer Backup & Restore; adds CLI/GUI run examples and update flow
> - Adds MCP client connectivity (with examples and recommended servers) and clarifies built-in MCP server endpoints; notes A2A usage and connection URL
> - Clarifies model configuration: provider-specific naming (remove `openai/` on OpenAI), utility model sizing, context-window tuning, and Ollama networking from containers
> - Documents projects, tasks/scheduler, and notifications workflows; adds secrets path (`/a0/tmp/secrets.env`) and chat history location (`/a0/tmp/chats/`)
> - Updates prompts guidance: overrides live in `/agents/<agent_profile>/prompts/`; clarifies tools vs instruments and adds memory/embedding notes
> - Improves architecture and development notes (directory layout, RFC/SSH workflow, legacy host execution pointers)
> - Expands troubleshooting with common setup pitfalls and fixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c4b45b65ac3b1d0f181a4d12c3e0bb23ec9c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->