### PR TITLE
Docs: refresh installation, MCP/A2A, Projects/Tasks, prompts and backup guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,10 +3,14 @@
 To begin with Agent Zero, follow the links below for detailed guides on various topics:
 
 - **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Agent Zero on your system.
+- **[Quickstart](quickstart.md):** Launch the Web UI and run your first task.
 - **[Usage Guide](usage.md):** Explore GUI features and usage scenarios.
 - **[Development](development.md):** Set up a development environment for Agent Zero.
 - **[Extensibility](extensibility.md):** Learn how to create custom extensions for Agent Zero.
 - **[Connectivity](connectivity.md):** Learn how to connect to Agent Zero from other applications.
+- **[MCP Setup](mcp_setup.md):** Configure external MCP tool servers.
+- **[Notifications](notifications.md):** Use the notification system in backend and UI code.
+- **[Tunnel](tunnel.md):** Expose Agent Zero safely over the internet.
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
 - **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
@@ -31,6 +35,7 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
   - [Using Agent Zero on Mobile](installation.md#using-agent-zero-on-your-mobile-device)
   - [How to Update Agent Zero](installation.md#how-to-update-agent-zero)
   - [Full Binaries Installation](installation.md#in-depth-guide-for-full-binaries-installation)
+- [Quickstart](quickstart.md)
 - [Usage Guide](usage.md)
   - [Basic Operations](usage.md#basic-operations)
     - [Restart Framework](usage.md#restart-framework)
@@ -39,11 +44,15 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
   - [Tool Usage](usage.md#tool-usage)
   - [Example of Tools Usage](usage.md#example-of-tools-usage-web-search-and-code-execution)
   - [Multi-Agent Cooperation](usage.md#multi-agent-cooperation)
+  - [Projects & Tasks](usage.md#projects--tasks)
   - [Prompt Engineering](usage.md#prompt-engineering)
   - [Voice Interface](usage.md#voice-interface)
   - [Mathematical Expressions](usage.md#mathematical-expressions)
   - [File Browser](usage.md#file-browser)
   - [Backup & Restore](usage.md#backup--restore)
+- [Development](development.md)
+- [Extensibility](extensibility.md)
+- [Connectivity](connectivity.md)
 - [Architecture Overview](architecture.md)
   - [System Architecture](architecture.md#system-architecture)
   - [Runtime Architecture](architecture.md#runtime-architecture)
@@ -53,16 +62,20 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
     - [Tools](architecture.md#2-tools)
     - [SearXNG Integration](architecture.md#searxng-integration)
     - [Memory System](architecture.md#3-memory-system)
-    - [Messages History and Summarization](archicture.md#messages-history-and-summarization)
+    - [Messages History and Summarization](architecture.md#messages-history-and-summarization)
     - [Prompts](architecture.md#4-prompts)
     - [Knowledge](architecture.md#5-knowledge)
     - [Instruments](architecture.md#6-instruments)
     - [Extensions](architecture.md#7-extensions)
-  - [Contributing](contribution.md)
+- [MCP Setup](mcp_setup.md)
+- [Notifications](notifications.md)
+- [Tunnel](tunnel.md)
+- [Contributing](contribution.md)
   - [Getting Started](contribution.md#getting-started)
   - [Making Changes](contribution.md#making-changes)
   - [Submitting a Pull Request](contribution.md#submitting-a-pull-request)
   - [Documentation Stack](contribution.md#documentation-stack)
 - [Troubleshooting and FAQ](troubleshooting.md)
   - [Frequently Asked Questions](troubleshooting.md#frequently-asked-questions)
-  - [Troubleshooting](troubleshooting.md#troubleshooting)
+  - [Common Errors & Fixes](troubleshooting.md#common-errors--fixes)
+  - [Docker & Runtime Issues](troubleshooting.md#docker--runtime-issues)

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -1,0 +1,143 @@
+# Documentation Audit Report (Pre-Update)
+
+This audit captures issues discovered before any edits. It is structured per documentation file and lists outdated content, gaps, and removals with reasons.
+
+> [!IMPORTANT]
+> This report was produced **before** any documentation edits. Use it as a rationale ledger for removals and updates.
+
+## docs/README.md
+**Outdated / Incorrect**
+- Table of contents is missing several docs (Quickstart, MCP setup, Notifications, Tunnel).
+- Broken anchor: `archicture.md#messages-history-and-summarization` (typo in filename).
+
+**Gaps**
+- No explicit links to MCP setup, Notifications, Tunnel, or Quickstart guides.
+- No quick navigation to Projects/Tasks/MCP/A2A sections.
+
+**Planned Removals (with reasons)**
+- None. Content is mostly accurate but incomplete.
+
+---
+
+## docs/installation.md
+**Outdated / Incorrect**
+- Hacking edition described as a separate image (`agent0ai/agent-zero:hacking`). Community guidance: hacker profile is included in main image and selected in Settings.
+- Prompt customization references `/prompts` subdirectories; post v0.9.7 custom prompts live under `/a0/agents/<agent_name>/` with only overrides.
+- Update instructions emphasize volume mapping and manual copying; community guidance recommends Backup & Restore as primary upgrade path.
+- Volume mapping section suggests mapping `/a0` is acceptable; community guidance explicitly discourages mapping full `/a0`.
+
+**Gaps**
+- Port mapping guidance should emphasize mapping at least one host port to container `80` (host port can be `0`).
+- Model naming by provider (OpenAI vs OpenRouter, Venice) is missing.
+- Utility model minimum capability guidance (>=70B recommended for memory extraction).
+- Context window configuration advice (set total context, then allocate memory share).
+- Clarification that OpenAI Plus does not include API credits.
+
+**Planned Removals (with reasons)**
+- Remove “map full `/a0` for persistence” guidance because it causes upgrade issues and is discouraged by maintainers.
+- Remove hacking image reference because it is no longer accurate; replaced by profile selection in Settings.
+
+---
+
+## docs/usage.md
+**Outdated / Incorrect**
+- Lacks mention of Tasks scheduler and Projects feature usage patterns.
+
+**Gaps**
+- Need to document Tasks + Projects workflow, and notification-driven automation.
+- Browser agent limitations and MCP alternatives (Browser OS, Chrome DevTools, Playwright) are missing.
+- Chat history location (`/a0/tmp/chats/`) is not mentioned.
+
+**Planned Removals (with reasons)**
+- None. Content is accurate but incomplete.
+
+---
+
+## docs/architecture.md
+**Outdated / Incorrect**
+- Prompt customization points to `/prompts/<subdir>` as the user override location; post v0.9.7 overrides are in `/a0/agents/<agent_name>/`.
+- Custom tool prompt location references `/prompts/$FOLDERNAME` without mentioning agent-specific overrides.
+
+**Gaps**
+- Clarify instruments vs tools distinction (tools are prompt-injected, instruments are not).
+- Mention local embedding model and memory extraction reliance on utility model.
+
+**Planned Removals (with reasons)**
+- Remove outdated prompt override instructions referencing `/prompts` subdirectories in favor of agent profile overrides.
+
+---
+
+## docs/extensibility.md
+**Outdated / Incorrect**
+- Prompts section references `/agents/{agent_profile}/prompts/` as the override location; community guidance indicates overrides live directly under `/a0/agents/<agent_name>/` with only custom files.
+
+**Gaps**
+- Instruments need clearer documentation and how they differ from tools.
+- Projects section should mention context separation and how Projects + Tasks combine.
+
+**Planned Removals (with reasons)**
+- Remove references to prompt overrides via `/prompts` subdirectories.
+
+---
+
+## docs/connectivity.md
+**Outdated / Incorrect**
+- A2A section lacks practical usage examples and context separation guidance.
+
+**Gaps**
+- Add practical A2A examples (e.g., two instances for isolated contexts).
+- Clarify MCP server vs MCP client usage in Agent Zero.
+
+**Planned Removals (with reasons)**
+- None.
+
+---
+
+## docs/mcp_setup.md
+**Outdated / Incorrect**
+- MCP client configuration is accurate but missing newly recommended MCP servers and browser alternatives.
+
+**Gaps**
+- Add guidance for Browser OS, Chrome DevTools MCP, Playwright MCP.
+- Mention n8n and Gmail MCP patterns.
+- Mention that browser agent is currently unstable and MCPs are preferred.
+
+**Planned Removals (with reasons)**
+- None.
+
+---
+
+## docs/quickstart.md
+**Outdated / Incorrect**
+- Assumes conda + `python run_ui.py` (legacy host runtime) as the primary path; Docker is now the standard.
+
+**Gaps**
+- Add quick Docker-based launch steps and port discovery.
+
+**Planned Removals (with reasons)**
+- Remove conda/host-runtime quickstart path to avoid steering users to deprecated setup.
+
+---
+
+## docs/troubleshooting.md
+**Outdated / Incorrect**
+- Lacks known error resolutions documented by maintainers (invalid model ID, temperature extra parameter).
+
+**Gaps**
+- Add model naming pitfalls, context window issues, temperature param errors, secrets backup caveat, and OpenAI API vs Plus clarification.
+- Add chat history location and secrets file location for recovery (`/a0/tmp/chats/`, `/a0/tmp/secrets.env`).
+
+**Planned Removals (with reasons)**
+- None.
+
+---
+
+## docs/notifications.md, docs/development.md, docs/tunnel.md
+**Outdated / Incorrect**
+- No critical inaccuracies found.
+
+**Gaps**
+- Ensure cross-links from Usage/Tasks/Projects to Notifications where relevant.
+
+**Planned Removals (with reasons)**
+- None.

--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -546,6 +546,10 @@ It provides two endpoint types:
 - **SSE (`/mcp/sse`):** For clients that support Server-Sent Events.
 - **Streamable HTTP (`/mcp/http/`):** For clients that use streamable HTTP requests.
 
+> [!NOTE]
+> Enable the MCP server in **Settings → MCP Server** before connecting external clients.
+> See [MCP Setup](mcp_setup.md) for the client-side configuration details.
+
 ### Example MCP Server Configuration
 
 Below is an example of a `mcp.json` configuration file that a client could use to connect to the Agent Zero MCP server. 
@@ -583,3 +587,10 @@ To connect another agent to your Agent Zero instance, use the following URL form
 ```
 YOUR_AGENT_ZERO_URL/a2a/t-YOUR_API_TOKEN
 ```
+
+### Practical A2A Patterns
+- **Context separation:** Run two Agent Zero instances and connect them via A2A so each handles distinct tasks or clients.
+- **Delegation pipelines:** Use a “coordinator” agent to offload sub-tasks to another instance (e.g., research vs. coding).
+
+> [!TIP]
+> A2A is a good alternative when a single instance’s Projects or subagents are not enough for strict isolation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,7 +58,7 @@ The following user guide provides instructions for installing and running Agent 
 
 2. **Run Agent Zero:**
 
-- Note: Agent Zero also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
+- Note: The Hacker profile (Kali-based environment + security-focused prompts) is included in the main image. After you launch the container, select the **hacker** profile in Settings instead of pulling a separate image.
 
 2.1. Pull the Agent Zero Docker image:
 - Search for `agent0ai/agent-zero` in Docker Desktop
@@ -71,44 +71,39 @@ The following user guide provides instructions for installing and running Agent 
 > Alternatively, run the following command in your terminal:
 >
 > ```bash
-> docker pull agent0ai/agent-zero
+> docker pull agent0ai/agent-zero:latest
 > ```
+
+> [!NOTE]
+> There is also a **testing** tag (`agent0ai/agent-zero:testing`) that may include pre-release features.
+> Use it only for experimentation and avoid storing critical data in that instance.
 
 2.2. OPTIONAL - Create a data directory for persistence:
 
 > [!CAUTION]
-> Preferred way of persisting Agent Zero data is to use the backup and restore feature.
-> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
+> The recommended persistence workflow is **Backup & Restore** (Settings → Backup & Restore).
+> Do **not** map the entire `/a0` directory, because it includes the running codebase and will
+> cause upgrade issues. Map only the specific folders you need for file exchange.
 
-- Choose or create a directory on your machine where you want to store Agent Zero's data
-- This can be any location you prefer (e.g., `C:/agent-zero-data` or `/home/user/agent-zero-data`)
-- You can map individual subfolders of `/a0` to a local directory or the full `/a0` directory (not recommended).
-- This directory will contain all your Agent Zero files, like the legacy root folder structure:
-  - `/agents` - Specialized agents with their prompts and tools
-  - `/memory` - Agent's memory and learned information
-  - `/knowledge` - Knowledge base
-  - `/instruments` - Instruments and functions
-  - `/prompts` - Prompt files
-  - `.env` - Your API keys
-  - `/tmp/settings.json` - Your Agent Zero settings
-
-> [!TIP]
-> Choose a location that's easy to access and backup. All your Agent Zero data 
-> will be directly accessible in this directory.
+- Choose or create a directory on your machine if you want a mapped workspace for files.
+- Recommended mappings are **narrow** and task-specific (for example `/a0/work_dir` or a
+  dedicated folder you want the agent to read/write).
+- Use Backup & Restore for settings, memory, knowledge, and prompts instead of a full `/a0` bind.
 
 2.3. Run the container:
 - In Docker Desktop, go back to the "Images" tab
 - Click the `Run` button next to the `agent0ai/agent-zero` image
 - Open the "Optional settings" menu
-- Set the web port (80) to desired host port number in the second "Host port" field or set to `0` for automatic port assignment
+- Ensure **at least one** host port is mapped to container port **80**
+  - Set host port to `0` for a random port assignment, or choose a fixed port (e.g., `50080`)
 
-Optionally you can map local folders for file persistence:
+Optionally you can map local folders for file exchange:
 > [!CAUTION]
-> Preferred way of persisting Agent Zero data is to use the backup and restore feature.
-> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
-- OPTIONAL: Under "Volumes", configure your mapped folders, if needed:
-  - Example host path: Your chosen directory (e.g., `C:\agent-zero\memory`)
-  - Example container path: `/a0/memory`
+> Avoid mapping the full `/a0` directory. Use Backup & Restore for persistence and map only
+> specific folders you want the agent to work with.
+- OPTIONAL: Under "Volumes", configure your mapped folders:
+  - Example host path: Your chosen directory (e.g., `C:\agent-zero\work`)
+  - Example container path: `/a0/work_dir`
 
 
 - Click the `Run` button in the "Images" tab.
@@ -123,10 +118,10 @@ Optionally you can map local folders for file persistence:
 > [!TIP]
 > Alternatively, run the following command in your terminal:
 > ```bash
-> docker run -p $PORT:80 -v /path/to/your/data:/a0 agent0ai/agent-zero
+> docker run -p $PORT:80 -v /path/to/your/work_dir:/a0/work_dir agent0ai/agent-zero:latest
 > ```
-> - Replace `$PORT` with the port you want to use (e.g., `50080`)
-> - Replace `/path/to/your/data` with your chosen directory path
+> - Replace `$PORT` with the port you want to use (or `0` for a random port)
+> - Replace `/path/to/your/work_dir` with your chosen directory path
 
 2.4. Access the Web UI:
 - The framework will take a few seconds to initialize and the Docker logs will look like the image below.
@@ -154,7 +149,7 @@ Optionally you can map local folders for file persistence:
 Agent Zero provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
 
 ### Agent Configuration
-- **Prompts Subdirectory:** Choose the subdirectory within `/prompts` for agent behavior customization. The 'default' directory contains the standard prompts.
+- **Agent Profile:** Select the agent profile (e.g., `default`, `developer`, `hacker`). Custom prompts now live in `/a0/agents/<agent_name>/` and only the files you override need to exist there (the rest are pulled from defaults).
 - **Memory Subdirectory:** Select the subdirectory for agent memory storage, allowing separation between different instances.
 - **Knowledge Subdirectory:** Specify the location of custom knowledge files to enhance the agent's understanding.
 
@@ -162,7 +157,7 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 
 ### Chat Model Settings
 - **Provider:** Select the chat model provider (e.g., Ollama)
-- **Model Name:** Choose the specific model (e.g., llama3.2)
+- **Model Name:** Choose the specific model (e.g., `llama3.2`). For OpenAI, use the model name **without** the `openai/` prefix (that prefix is for OpenRouter only).
 - **API URL:** URL of the API endpoint for the chat model - only needed for custom providers like Ollama, Azure, etc.
 - **Context Length:** Set the maximum token limit for context window
 - **Context Window Space:** Configure how much of the context window is dedicated to chat history
@@ -170,7 +165,7 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 ![chat model settings](res/setup/settings/2-chat-model.png)
 
 ### Utility Model Configuration
-- **Provider & Model:** Select a smaller, faster model for utility tasks like memory organization and summarization
+- **Provider & Model:** Select a smaller, faster model for utility tasks like memory organization and summarization. For reliable memory extraction, use a **capable model** (community guidance recommends ~70B+ or a strong hosted model like Gemini Flash, GPT-mini, or Grok Fast).
 - **Temperature:** Adjust the determinism of utility responses
 
 ### Embedding Model Settings
@@ -224,6 +219,29 @@ The Settings page is the control center for selecting the Large Language Models 
 3. Click "Save" to apply the changes.
 
 ## Important Considerations
+### Provider Model Naming
+Model naming differs by provider. A common error is using an OpenRouter-style prefix on native OpenAI or Venice providers.
+
+| Provider | Model name format | Example |
+| --- | --- | --- |
+| OpenAI | model name only | `gpt-4.1` |
+| OpenRouter | provider prefix required | `openai/gpt-4.1` |
+| Venice | model name with optional params | `qwen3-235b:disable_thinking=true` |
+| Ollama | model name only | `llama3.2` |
+
+> [!TIP]
+> If you see **Invalid model ID**, double-check the provider and whether a prefix is required.
+
+### Context Window and Memory Allocation
+Set the **total context window** first (e.g., `100k`), then allocate the memory portion.  
+If the total context window is extremely large, even small percentages can consume huge token budgets.
+
+### Utility Model Capability
+Utility models handle summarization, memory extraction, and internal orchestration.  
+Community guidance suggests using a **strong** utility model (roughly 70B+ or a hosted fast model) for reliable memory extraction.
+
+### OpenAI API vs Plus Subscription
+OpenAI Plus subscriptions do **not** include API credits. You still need a separate API key for Agent Zero.
 
 ## Installing and Using Ollama (Local Models)
 If you're interested in Ollama, which is a powerful tool that allows you to run various large language models locally, here's how to install and use it:
@@ -247,7 +265,8 @@ curl -fsSL https://ollama.com/install.sh | sh
 ```
 
 **Finding Model Names:**
-Visit the [Ollama model library](https://ollama.com/library) for a list of available models and their corresponding names.  The format is usually `provider/model-name` (or just `model-name` in some cases).
+Visit the [Ollama model library](https://ollama.com/library) for a list of available models and their corresponding names.  
+For Ollama, use the **model name only** (for example, `llama3.2`).
 
 #### Second step: pulling the model
 **On Windows, macOS, and Linux:**
@@ -271,6 +290,10 @@ ollama pull <model-name>
 5. Click `Save` to confirm your settings.
 
 ![ollama](res/setup/settings/4-local-models.png)
+
+> [!TIP]
+> If Ollama runs outside the Agent Zero container, make sure port **11434** is reachable.
+> On shared Docker networks, you can often use `http://<ollama-container-name>:11434`.
 
 #### Managing your downloaded models
 Once you've downloaded some models, you might want to check which ones you have available or remove any you no longer need.
@@ -318,63 +341,37 @@ For developers or users who need to run Agent Zero directly on their system,see 
 # How to update Agent Zero
 
 > [!NOTE]
-> Since v0.9, Agent Zero has a Backup and Restore feature, so you don't need to backup the files manually.
-> In Settings, Backup and Restore tab will guide you through the process.
+> Since v0.9, the **Backup & Restore** panel is the recommended upgrade path. It avoids volume-mapping issues and keeps upgrades smooth.
 
-1. **If you come from the previous version of Agent Zero:**
-- Your data is safely stored across various directories and files inside the Agent Zero folder.
-- To update to the new Docker runtime version, you might want to backup the following files and directories:
-  - `/memory` - Agent's memory
-  - `/knowledge` - Custom knowledge base (if you imported any custom knowledge files)
-  - `/instruments` - Custom instruments and functions (if you created any custom)
-  - `/tmp/settings.json` - Your Agent Zero settings
-  - `/tmp/chats/` - Your chat history
-- Once you have saved these files and directories, you can proceed with the Docker runtime [installation instructions above](#windows-macos-and-linux-setup-guide) setup guide.
-- Reach for the folder where you saved your data and copy it to the new Agent Zero folder set during the installation process.
-- Agent Zero will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
+## Recommended update flow (Docker Desktop or CLI)
+1. **Keep your current container running** (don’t delete it yet).
+2. **Pull the new image** (`agent0ai/agent-zero:latest`).
+3. **Start a new container** from the new image.
+4. **Create a backup** in the old instance (Settings → Backup & Restore).
+5. **Restore the backup** in the new instance.
 
 > [!IMPORTANT]
-> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Agent Zero generate a new one.
-> The same goes for chats in `/tmp/chats/`, they might be incompatible with the new version
-
-2. **Update Process (Docker Desktop)**
-- Go to Docker Desktop and stop the container from the "Containers" tab
-- Right-click and select "Remove" to remove the container
-- Go to "Images" tab and remove the `agent0ai/agent-zero` image or click the three dots to pull the difference and update the Docker image.
-
-![docker delete image](res/setup/docker-delete-image-1.png)
-
-- Search and pull the new image if you chose to remove it
-- Run the new container with the same volume settings as the old one
-
-> [!IMPORTANT]
-> Make sure to use the same volume mount path when running the new
-> container to preserve your data. The exact path depends on where you stored
-> your Agent Zero data directory (the chosen directory on your machine).
+> Secrets are stored in `/a0/tmp/secrets.env` and are **not included** in backups. Copy them manually if needed.
 
 > [!TIP]
-> Alternatively, run the following commands in your terminal:
->
-> ```bash
-> # Stop the current container
-> docker stop agent-zero
->
-> # Remove the container (data is safe in the folder)
-> docker rm agent-zero
->
-> # Remove the old image
-> docker rmi agent0ai/agent-zero
->
-> # Pull the latest image
-> docker pull agent0ai/agent-zero
->
-> # Run new container with the same volume mount
-> docker run -p $PORT:80 -v /path/to/your/data:/a0 agent0ai/agent-zero
-> ```
+> Chat history lives under `/a0/tmp/chats/` if you need to manually preserve or inspect old chat logs.
+
+## Optional Linux/VPS update commands
+```bash
+export IMAGE="agent0ai/agent-zero:latest"
+
+# Stop existing containers for this image
+docker ps -a -q --filter ancestor=$IMAGE | xargs -r docker stop
+
+# Remove containers
+docker ps -a -q --filter ancestor=$IMAGE | xargs -r docker rm
+
+# Pull latest image
+docker pull $IMAGE
+```
 
       
 ### Conclusion
 After following the instructions for your specific operating system, you should have Agent Zero successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
 
 If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.
-

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -2,6 +2,9 @@
 
 This guide explains how to configure and utilize external tool providers through the Model Context Protocol (MCP) with Agent Zero. This allows Agent Zero to leverage tools hosted by separate local or remote MCP-compliant servers.
 
+> [!NOTE]
+> Agent Zero can act as **both** an MCP client (this guide) and an MCP server. For exposing Agent Zero to external MCP clients, see [MCP Server Connectivity](connectivity.md#mcp-server-connectivity).
+
 ## What are MCP Servers?
 
 MCP servers are external processes or services that expose a set of tools that Agent Zero can use. Agent Zero acts as an MCP *client*, consuming tools made available by these servers. The integration supports three main types of MCP servers:
@@ -18,7 +21,7 @@ Agent Zero discovers and integrates MCP tools dynamically:
 2.  **Saving Settings**: When you save your settings via the UI, Agent Zero updates the `tmp/settings.json` file, specifically the `"mcp_servers"` key.
 3.  **Automatic Installation (on Restart)**: After saving your settings and restarting Agent Zero, the system will attempt to automatically install any MCP server packages defined with `command: "npx"` and the `--package` argument in their configuration (this process is managed by `initialize.py`). You can monitor the application logs (e.g., Docker logs) for details on this installation attempt.
 4.  **Tool Discovery**: Upon initialization (or when settings are updated), Agent Zero connects to each configured and enabled MCP server and queries it for the list of available tools, their descriptions, and expected parameters.
-5.  **Dynamic Prompting**: The information about these discovered tools is then dynamically injected into the agent's system prompt. A placeholder like `{{tools}}` in a system prompt template (e.g., `prompts/default/agent.system.mcp_tools.md`) is replaced with a formatted list of all available MCP tools. This allows the agent's underlying Language Model (LLM) to know which external tools it can request.
+5.  **Dynamic Prompting**: The information about these discovered tools is then dynamically injected into the agent's system prompt. A placeholder like `{{tools}}` in a system prompt template (e.g., `prompts/agent.system.mcp_tools.md`) is replaced with a formatted list of all available MCP tools. This allows the agent's underlying Language Model (LLM) to know which external tools it can request.
 6.  **Tool Invocation**: When the LLM decides to use an MCP tool, Agent Zero's `process_tools` method (handled by `mcp_handler.py`) identifies it as an MCP tool and routes the request to the appropriate `MCPConfig` helper, which then communicates with the designated MCP server to execute the tool.
 
 ## Configuration
@@ -144,3 +147,20 @@ Once configured, successfully installed (if applicable, e.g., for `npx` based se
 *   **Execution Flow**: Agent Zero's `process_tools` method (with logic in `python/helpers/mcp_handler.py`) prioritizes looking up the tool name in the `MCPConfig`. If found, the execution is delegated to the corresponding MCP server. If not found as an MCP tool, it then attempts to find a local/built-in tool with that name.
 
 This setup provides a flexible way to extend Agent Zero's capabilities by integrating with various external tool providers without modifying its core codebase.
+
+## Recommended MCP Servers & Patterns
+
+### Browser Automation (Preferred Right Now)
+The built-in browser agent currently has dependency issues. MCP alternatives are more stable:
+- **Browser OS MCP**
+- **Chrome DevTools MCP**
+- **Playwright MCP**
+
+These provide a reliable browser surface while the native browser agent is being stabilized.
+
+### Automation & Integrations
+- **n8n MCP**: Community members use n8n to orchestrate workflows, triggers, and integrations.
+- **Gmail MCP**: Pair with Tasks to poll inboxes and send scheduled summaries.
+
+> [!TIP]
+> When running MCP servers on your host machine, remember Agent Zero is in Docker. You may need to expose ports, or place both containers on the same Docker network.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,39 +1,30 @@
 # Quick Start
-This guide provides a quick introduction to using Agent Zero. We'll cover launching the web UI, starting a new chat, and running a simple task.
+This guide provides a quick introduction to using Agent Zero. We'll cover launching the Web UI, starting a new chat, and running a simple task.
 
-## Launching the Web UI
-1. Make sure you have Agent Zero installed and your environment set up correctly (refer to the [Installation guide](installation.md) if needed).
-2. Open a terminal in the Agent Zero directory and activate your conda environment (if you're using one).
-3. Run the following command:
+## Launching the Web UI (Docker)
+1. Make sure you have Agent Zero installed (see the [Installation guide](installation.md)).
+2. Run the container and map a host port to container port **80**.
+   - In Docker Desktop, choose **Optional settings** and set the host port (use `0` for a random port).
+   - On the CLI, run:
 
 ```bash
-python run_ui.py
+docker run -p 50080:80 agent0ai/agent-zero:latest
 ```
 
-4.  A message similar to this will appear in your terminal, indicating the Web UI is running:
-
-![](res/flask_link.png)
-
-5. Open your web browser and navigate to the URL shown in the terminal (usually `http://127.0.0.1:50001`). You should see the Agent Zero Web UI.
+3. Open your browser and navigate to the mapped port (for example `http://localhost:50080`).
+4. You should see the Agent Zero Web UI:
 
 ![New Chat](res/ui_newchat1.png)
 
 > [!TIP]
-> As you can see, the Web UI has four distinct buttons for easy chat management: 
-> `New Chat`, `Reset Chat`, `Save Chat`, and `Load Chat`.
-> Chats can be saved and loaded individually in `json` format and are stored in the
-> `/tmp/chats` directory.
-
-    ![Chat Management](res/ui_chat_management.png)
+> The Web UI has quick chat management buttons (New, Reset, Save, Load). Chats are stored under `/a0/tmp/chats/` inside the container.
 
 ## Running a Simple Task
 Let's ask Agent Zero to download a YouTube video. Here's how:
 
-1.  Type "Download a YouTube video for me" in the chat input field and press Enter or click the send button.
-
-2. Agent Zero will process your request.  You'll see its "thoughts" and the actions it takes displayed in the UI. It will find a default already existing solution, that implies using the `code_execution_tool` to run a simple Python script to perform the task.
-
-3. The agent will then ask you for the URL of the YouTube video you want to download.
+1. Type "Download a YouTube video for me" in the chat input field and press Enter or click the send button.
+2. Agent Zero will process your request and outline the steps it plans to take.
+3. The agent will ask you for the URL of the YouTube video you want to download.
 
 ## Example Interaction
 Here's an example of what you might see in the Web UI at step 3:
@@ -49,6 +40,4 @@ Now that you've run a simple task, you can experiment with more complex requests
 * Create or modify files
 
 > [!TIP]
-> The [Usage Guide](usage.md) provides more in-depth information on using Agent 
-> Zero's various features, including prompt engineering, tool usage, and multi-agent 
-> cooperation.
+> The [Usage Guide](usage.md) provides more in-depth information on using Agent Zero's features, including tools, projects, tasks, and backup/restore.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,43 +2,67 @@
 This page addresses frequently asked questions (FAQ) and provides troubleshooting steps for common issues encountered while using Agent Zero.
 
 ## Frequently Asked Questions
-**1. How do I ask Agent Zero to work directly on my files or dirs?**
--   Place the files/dirs in the `work_dir` directory. Agent Zero will be able to perform tasks on them. The `work_dir` directory is located in the root directory of the Docker Container.
 
-**2. When I input something in the chat, nothing happens. What's wrong?**
--   Check if you have set up API keys in the Settings page. If not, the application will not be able to communicate with the endpoints it needs to run LLMs and to perform tasks.
+**1. How do I ask Agent Zero to work directly on my files or directories?**
+- Place the files in `/a0/work_dir` (or a mapped folder you mounted into the container). The agent’s working directory defaults to `/work_dir` inside the container.
 
-**3. How do I integrate open-source models with Agent Zero?**
-Refer to the [Choosing your LLMs](installation.md#installing-and-using-ollama-local-models) section of the documentation for detailed instructions and examples for configuring different LLMs. Local models can be run using Ollama or LM Studio.
+**2. When I input something in the chat, nothing happens. What’s wrong?**
+- Ensure you configured API keys in **Settings → External Services**. Without a working LLM provider, the agent cannot respond.
 
-> [!TIP]
-> Some LLM providers offer free usage of their APIs, for example Groq, Mistral, SambaNova or CometAPI.
+**3. How do I integrate open-source models (Ollama, LM Studio, etc.)?**
+- See [Installing and Using Ollama](installation.md#installing-and-using-ollama-local-models). Ensure port **11434** is reachable from the container.
 
-**6. How can I make Agent Zero retain memory between sessions?**
-Refer to the [How to update Agent Zero](installation.md#how-to-update-agent-zero) section of the documentation for instructions on how to update Agent Zero while retaining memory and data.
+**4. How do I retain memory and settings between updates?**
+- Use **Settings → Backup & Restore**. Avoid mapping the entire `/a0` directory, which causes upgrade issues.
 
-**7. Where can I find more documentation or tutorials?**
--   Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for support and discussions.
+**5. Where are chat logs stored?**
+- Chat history lives under `/a0/tmp/chats/`.
 
-**8. How do I adjust API rate limits?**
-Modify the `rate_limit_seconds` and `rate_limit_requests` parameters in the `AgentConfig` class within `initialize.py`.
+**6. My OpenAI Plus subscription isn’t working.**
+- Plus does **not** include API credits. You still need an API key for Agent Zero.
 
-**9. My code_execution_tool doesn't work, what's wrong?**
--   Ensure you have Docker installed and running.  If using Docker Desktop on macOS, grant it access to your project files in Docker Desktop's settings.  Check the [Installation guide](installation.md#4-install-docker-docker-desktop-application) for more details.
--   Verify that the Docker image is updated.
+**7. My browser agent keeps failing.**
+- The built-in browser agent is currently unstable. Use MCP-based alternatives (Browser OS, Chrome DevTools, Playwright) instead. See [MCP setup](mcp_setup.md).
 
-**10. Can Agent Zero interact with external APIs or services (e.g., WhatsApp)?**
-Extending Agent Zero to interact with external APIs is possible by creating custom tools or solutions. Refer to the documentation on creating them. 
+**8. Secrets disappeared after backup/restore.**
+- Secrets are stored in `/a0/tmp/secrets.env` and are **not** included in backups. Copy this file manually.
 
-## Troubleshooting
+---
 
-**Installation**
-- **Docker Issues:** If Docker containers fail to start, consult the Docker documentation and verify your Docker installation and configuration.  On macOS, ensure you've granted Docker access to your project files in Docker Desktop's settings as described in the [Installation guide](installation.md#4-install-docker-docker-desktop-application). Verify that the Docker image is updated.
+## Common Errors & Fixes
 
-**Usage**
+### Invalid Model ID
+**Symptom:** "Invalid model ID" or provider errors.  
+**Fix:** Ensure the model name matches the provider:
+- **OpenAI:** use `gpt-4.1` (no `openai/` prefix)
+- **OpenRouter:** use `openai/gpt-4.1`
 
-- **Terminal commands not executing:** Ensure the Docker container is running and properly configured.  Check SSH settings if applicable. Check if the Docker image is updated by removing it from Docker Desktop app, and subsequently pulling it again.
+### Context Window Issues
+**Symptom:** Truncated or missing context.  
+**Fix:** Set total context window size (e.g., `100k`) and then allocate memory portion. Avoid overly large totals with large memory percentages.
 
-* **Error Messages:** Pay close attention to the error messages displayed in the Web UI or terminal.  They often provide valuable clues for diagnosing the issue. Refer to the specific error message in online searches or community forums for potential solutions.
+### Utility Model Too Small
+**Symptom:** Poor memory extraction or unreliable summaries.  
+**Fix:** Use a stronger utility model (community guidance: ~70B+ or a strong hosted fast model).
 
-* **Performance Issues:** If Agent Zero is slow or unresponsive, it might be due to resource limitations, network latency, or the complexity of your prompts and tasks, especially when using local models.
+### Temperature Parameter Errors
+**Symptom:** Provider rejects requests or returns errors about temperature.  
+**Fix:** Remove `temperature=0` or unsupported parameters from model settings and retry.
+
+### 403 / WAF Errors (Venice API)
+**Symptom:** 403 or WAF-blocked responses.  
+**Fix:** This is typically a WAF restriction. Check provider status and retry; consider disabling automated retries if the endpoint blocks bots.
+
+---
+
+## Docker & Runtime Issues
+
+- **Container won’t start:** Restart Docker Desktop and ensure the image is up to date.
+- **Web UI not accessible:** Confirm that a host port is mapped to container port **80**.
+- **Terminal commands not executing:** Verify the container is running and that you are using the correct shell tool.
+
+---
+
+## More Help
+- Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community.
+- Review [Installation](installation.md) and [Usage](usage.md) guides for advanced configuration.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,6 +59,9 @@ Access the chat history in JSON format
   - View the conversation as processed by the LLM
   - Useful for debugging and understanding agent behavior
 
+> [!NOTE]
+> Chat history files live in `/a0/tmp/chats/`. This is helpful when you need to inspect or migrate logs manually.
+
 ![History](res/ui-history.png)
 
 * **Nudge:** Restart the agent's last process
@@ -102,6 +105,9 @@ Agent Zero's power comes from its ability to use [tools](architecture.md#tools).
 
 - **Understand Tools:** Agent Zero includes default tools like knowledge (powered by SearXNG), code execution, and communication. Understand the capabilities of these tools and how to invoke them.
 
+> [!CAUTION]
+> The built-in browser agent is currently unstable due to dependency issues. For reliable browser automation, use MCP servers such as **Browser OS**, **Chrome DevTools**, or **Playwright**. See the [MCP setup guide](mcp_setup.md) for configuration details.
+
 ## Example of Tools Usage: Web Search and Code Execution
 Let's say you want Agent Zero to perform some financial analysis tasks. Here's a possible prompt:
 
@@ -128,6 +134,23 @@ One of Agent Zero's unique features is multi-agent cooperation.
 
 ![](res/physics.png)
 ![](res/physics-2.png)
+
+## Projects & Tasks
+Projects and Tasks provide the best way to keep work separated and automate recurring workflows.
+
+### Projects (Context Separation)
+- Each Project has its **own context**, instructions, knowledge, and optional memory scope.
+- Projects are ideal for client work, long-running research threads, or parallel workflows that should never cross-contaminate.
+- Subagents spawned inside a Project inherit the Project context and settings.
+
+See [Projects in Extensibility](extensibility.md#projects) for structure details and how project instructions/knowledge are loaded.
+
+### Tasks & Scheduling
+- You can schedule tasks either by **asking the agent** or via **Settings → Tasks Scheduler**.
+- Scheduled tasks spawn a dedicated chat at the configured time, which is useful for monitoring, reporting, or periodic cleanup.
+
+> [!TIP]
+> Pair **Tasks + Projects + Notifications** to build “always-on” workflows (e.g., scheduled email checks or daily reports). See [Notifications](notifications.md) for event hooks and UI alerts.
 
 ## Prompt Engineering
 Effective prompt engineering is crucial for getting the most out of Agent Zero. Here are some tips and techniques:
@@ -188,6 +211,8 @@ Configure STT settings in the Settings page:
 > All STT and TTS functionalities operate locally within the Docker container,
 > ensuring that no data is transmitted to external servers or OpenAI APIs. This
 > enhances user privacy while maintaining functionality.
+
+## Mathematical Expressions
 
 
 * **Complex Mathematics:** Supports full KaTeX syntax for:
@@ -258,7 +283,7 @@ By default, Agent Zero backs up your most important data:
 * **Knowledge Base**: Your custom knowledge files and documents
 * **Memory System**: Agent memories and learned information
 * **Chat History**: All your conversations and interactions
-* **Configuration Files**: Settings, API keys, and system preferences
+* **Configuration Files**: Settings and system preferences (secrets in `/a0/tmp/secrets.env` are not included)
 * **Custom Instruments**: Any tools you've added or modified
 * **Uploaded Files**: Documents and files you've worked with
 
@@ -327,7 +352,7 @@ Optionally clean up existing files before restoring:
 * **Test Restores**: Occasionally test restoring backups to ensure they work
 
 #### Security Considerations
-* **API Keys**: Backups include your API keys and sensitive configuration
+* **Secrets**: Backups do **not** include `/a0/tmp/secrets.env`. Copy this file manually if you rely on secrets.
 * **Secure Storage**: Store backup files securely and don't share them
 * **Clean Systems**: When restoring on new systems, verify all configurations
 


### PR DESCRIPTION
### Motivation
- Bring documentation in line with recent community-verified behavior and features (MCP, A2A, Projects/Tasks, Instruments, prompt overrides).
- Reduce user confusion and support load by clarifying Docker best practices, port mapping, and the recommended `Backup & Restore` update path.
- Ensure documentation is accurate for both humans and AI consumers by adding a pre-edit audit and improving cross-linking and navigation.

### Description
- Added a structured audit (`docs/audit-report.md`) and updated `docs/README.md` to fix anchors and include missing sections like Quickstart, MCP, Notifications, and Tunnel.
- Revised `docs/installation.md` to recommend mapping a host port to container port `80`, discourage binding the full `/a0` tree, promote `Backup & Restore` for upgrades, document `agent0ai/agent-zero:latest` (and `:testing`), and add provider-specific model naming and utility-model guidance.
- Updated user-facing guides (`docs/usage.md`, `docs/quickstart.md`, `docs/troubleshooting.md`) to add `Projects & Tasks` usage and scheduler tips, note the chat history path at `/a0/tmp/chats/`, clarify that secrets live at `/a0/tmp/secrets.env`, and warn that the built-in browser agent is unstable and recommend MCP alternatives like Browser OS, Chrome DevTools, or Playwright.
- Clarified developer/extension docs (`docs/architecture.md`, `docs/extensibility.md`, `docs/mcp_setup.md`) to state that default prompts live in `/prompts/` while overrides belong under the agent profile at `/a0/agents/<agent_name>/`, explained `tools` vs `instruments`, and added MCP server/client notes and practical A2A patterns.

### Testing
- No automated tests were run because this PR contains documentation-only changes; repository CI (docs build/link checks) should validate links and formatting on merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df404c000832ea80665d4934a4392)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major docs refresh aligning guidance with current behavior and best practices.
> 
> - Installation now Docker-first: map a host port to `80`, discourage binding full `/a0`, promote **Backup & Restore** for upgrades; document `:latest`/`:testing`, provider-specific model naming, utility model capability, context window tips, and OpenAI Plus caveat
> - Clarifies prompt architecture: defaults in `/prompts/`, agent-specific overrides in `/a0/agents/<agent_name>/`; adds `/agents` dir to structure; updates custom tool prompt paths
> - Introduces and distinguishes **Instruments** vs **Tools**; expands Projects with true context separation and Tasks scheduling tips
> - Connectivity: adds MCP server enablement note and links; documents practical A2A patterns (context separation, delegation)
> - MCP setup: simplifies prompt placeholder path, adds recommended MCP servers (Browser OS, Chrome DevTools, Playwright), plus n8n/Gmail patterns and Docker networking tip
> - Usage/Quickstart/Troubleshooting: Docker-based quickstart, chat logs at `/a0/tmp/chats/`, secrets at `/a0/tmp/secrets.env` (not in backups), browser-agent instability warning with MCP alternatives, common error fixes
> - README ToC expanded (Quickstart, MCP, Notifications, Tunnel; Projects & Tasks); adds pre-edit `docs/audit-report.md` for rationale
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c81ef9a40f5a9d6238ec7565531f6892a8fbf9b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->