### PR TITLE
Move banner helpers into banner store and wire welcome banners

### DIFF
--- a/python/api/welcome_banners.py
+++ b/python/api/welcome_banners.py
@@ -1,0 +1,10 @@
+from python.helpers.api import ApiHandler, Request, Response
+
+
+class WelcomeBanners(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        # Placeholder for backend-generated welcome banners.
+        # Frontend provides context and any precomputed banners.
+        _ = input.get("frontend_banners", [])
+        _ = input.get("context", {})
+        return {"banners": []}

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -437,7 +437,7 @@ def _write_sensitive_settings(settings: Settings):
         dotenv.save_dotenv_value(dotenv.KEY_AUTH_PASSWORD, settings["auth_password"])
     if settings["rfc_password"] != PASSWORD_PLACEHOLDER:
         dotenv.save_dotenv_value(dotenv.KEY_RFC_PASSWORD, settings["rfc_password"])
-    if settings["root_password"] != PASSWORD_PLACEHOLDER:
+    if settings["root_password"] and settings["root_password"] != PASSWORD_PLACEHOLDER:
         dotenv.save_dotenv_value(dotenv.KEY_ROOT_PASSWORD, settings["root_password"])
         set_root_password(settings["root_password"])
 

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -437,7 +437,7 @@ def _write_sensitive_settings(settings: Settings):
         dotenv.save_dotenv_value(dotenv.KEY_AUTH_PASSWORD, settings["auth_password"])
     if settings["rfc_password"] != PASSWORD_PLACEHOLDER:
         dotenv.save_dotenv_value(dotenv.KEY_RFC_PASSWORD, settings["rfc_password"])
-    if settings["root_password"] and settings["root_password"] != PASSWORD_PLACEHOLDER:
+    if settings["root_password"] != PASSWORD_PLACEHOLDER:
         dotenv.save_dotenv_value(dotenv.KEY_ROOT_PASSWORD, settings["root_password"])
         set_root_password(settings["root_password"])
 

--- a/webui/components/banners/banner-store.js
+++ b/webui/components/banners/banner-store.js
@@ -27,13 +27,14 @@ const model = {
     return checks.flatMap((check) => check(input) || []);
   },
 
-  createBanner({ id, title, type, priority, html }) {
+  createBanner({ id, title, type, priority, html, actions }) {
     return {
       id: id || null,
       title: title?.trim() || "",
       type: type || BANNER_TYPES.INFO,
       priority: Number.isFinite(priority) ? priority : 0,
       html: html || "",
+      actions: actions || [],
     };
   },
 
@@ -77,7 +78,11 @@ const model = {
     });
   },
 
-  getBannerClass(type, prefix = "banner") {
+  getBannerClass(typeOrBanner, prefix = "banner") {
+    const type =
+      typeOrBanner && typeof typeOrBanner === "object"
+        ? typeOrBanner.type
+        : typeOrBanner;
     const normalized = type || BANNER_TYPES.INFO;
     return `${prefix}-${normalized}`;
   },

--- a/webui/components/banners/banner-store.js
+++ b/webui/components/banners/banner-store.js
@@ -1,0 +1,99 @@
+import { createStore } from "/js/AlpineStore.js";
+
+export const BANNER_TYPES = Object.freeze({
+  INFO: "info",
+  WARNING: "warning",
+  ERROR: "error",
+});
+
+export const BANNER_PRIORITY = Object.freeze({
+  HIGH: 100,
+  MEDIUM: 50,
+  LOW: 10,
+});
+
+const model = {
+  checksByScope: {},
+
+  registerCheck(scope, check) {
+    if (!scope || typeof check !== "function") return;
+    const registry = this.checksByScope[scope] || [];
+    registry.push(check);
+    this.checksByScope[scope] = registry;
+  },
+
+  runChecks(scope, input) {
+    const checks = this.checksByScope[scope] || [];
+    return checks.flatMap((check) => check(input) || []);
+  },
+
+  createBanner({ id, title, type, priority, html }) {
+    return {
+      id: id || null,
+      title: title?.trim() || "",
+      type: type || BANNER_TYPES.INFO,
+      priority: Number.isFinite(priority) ? priority : 0,
+      html: html || "",
+    };
+  },
+
+  normalizeBanner(banner, source) {
+    if (!banner || typeof banner !== "object") return null;
+    const normalized = this.createBanner(banner);
+    if (!normalized.title || !normalized.html) return null;
+    return { ...normalized, source };
+  },
+
+  assignBannerKeys(banners) {
+    return banners.map((banner, index) => ({
+      ...banner,
+      key: banner.id || `${banner.source || "banner"}-${index}`,
+    }));
+  },
+
+  mergeBanners(frontendBanners, backendBanners) {
+    const merged = [];
+    const seenIds = new Set();
+    const addBanner = (banner, source) => {
+      const normalized = this.normalizeBanner(banner, source);
+      if (!normalized) return;
+      if (normalized.id) {
+        if (seenIds.has(normalized.id)) return;
+        seenIds.add(normalized.id);
+      }
+      merged.push(normalized);
+    };
+
+    (frontendBanners || []).forEach((banner) => addBanner(banner, "frontend"));
+    (backendBanners || []).forEach((banner) => addBanner(banner, "backend"));
+    return this.assignBannerKeys(merged);
+  },
+
+  sortBanners(banners) {
+    return [...(banners || [])].sort((a, b) => {
+      const priorityA = Number.isFinite(a?.priority) ? a.priority : 0;
+      const priorityB = Number.isFinite(b?.priority) ? b.priority : 0;
+      return priorityB - priorityA;
+    });
+  },
+
+  getBannerClass(type, prefix = "banner") {
+    const normalized = type || BANNER_TYPES.INFO;
+    return `${prefix}-${normalized}`;
+  },
+
+  getBannerIcon(type) {
+    switch (type) {
+      case BANNER_TYPES.WARNING:
+        return "warning";
+      case BANNER_TYPES.ERROR:
+        return "error";
+      default:
+        return "info";
+    }
+  },
+};
+
+const store = createStore("bannerStore", model);
+
+export { store };

--- a/webui/components/banners/banners.html
+++ b/webui/components/banners/banners.html
@@ -1,0 +1,134 @@
+<html>
+
+<body>
+    <div x-data x-show="$store.welcomeStore && $store.welcomeStore.sortedBanners.length > 0">
+        <div class="welcome-banners">
+            <template x-for="banner in $store.welcomeStore.sortedBanners" :key="banner.key">
+                <div class="welcome-banner" :class="$store.welcomeStore.getBannerClass(banner.type)">
+                    <div class="welcome-banner-header">
+                        <span class="material-symbols-outlined welcome-banner-icon"
+                            x-text="$store.welcomeStore.getBannerIcon(banner.type)"></span>
+                        <div class="welcome-banner-title" x-text="banner.title"></div>
+                    </div>
+                    <div class="welcome-banner-body" x-html="banner.html"></div>
+                    <template x-if="banner.actions && banner.actions.length > 0">
+                        <div class="welcome-banner-actions">
+                            <template x-for="action in banner.actions" :key="action.label">
+                                <button class="btn btn-ok" type="button"
+                                    @click="$store.welcomeStore[action.action](...(action.args || []))"
+                                    x-text="action.label"></button>
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <style>
+        .welcome-banner-actions {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 0.2rem;
+        }
+
+        .welcome-banners {
+            position: fixed;
+            transform: translateX(-50%);
+            bottom: 2rem;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            text-align: left;
+            pointer-events: none;
+            width: 50%;
+        }
+
+        .welcome-banner {
+            pointer-events: auto; /* Enable clicks on the banner itself */
+            background: var(--color-panel);
+            border: 1px solid var(--color-border);
+            border-left-width: 4px;
+            border-radius: 12px;
+            padding: 1rem 1.2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.6rem;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2); /* Enhanced shadow for "on top" feel */
+            animation: slideUp 0.3s ease-out;
+        }
+
+        @keyframes slideUp {
+            from {
+                transform: translateY(20px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        .welcome-banner-info {
+            border-left-color: var(--color-highlight);
+        }
+
+        .welcome-banner-warning {
+            border-left-color: var(--color-warning);
+        }
+
+        .welcome-banner-error {
+            border-left-color: var(--color-error);
+        }
+
+        .welcome-banner-header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .welcome-banner-icon {
+            font-size: 1.4rem;
+        }
+
+        .welcome-banner-info .welcome-banner-icon {
+            color: var(--color-highlight);
+        }
+
+        .welcome-banner-warning .welcome-banner-icon {
+            color: var(--color-warning);
+        }
+
+        .welcome-banner-error .welcome-banner-icon {
+            color: var(--color-error);
+        }
+
+        .welcome-banner-title {
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        .welcome-banner-body {
+            font-size: 0.9rem;
+            line-height: 1.5;
+        }
+
+        .welcome-banner-body p {
+            margin: 0 0 1rem 0;
+            color: var(--color-text);
+            opacity: 0.7;
+        }
+
+
+        /* Responsive design */
+        @media (max-width: 768px) {
+            .welcome-banners {
+                width: 80%;
+            }
+        }
+    </style>
+</body>
+
+</html>
+

--- a/webui/components/welcome/welcome-screen.html
+++ b/webui/components/welcome/welcome-screen.html
@@ -68,19 +68,8 @@
                     </div>
                 </div>
 
-                <!-- Contextual Banners -->
-                <div class="welcome-banners" x-show="sortedBanners.length > 0">
-                    <template x-for="banner in sortedBanners" :key="banner.key">
-                        <div class="welcome-banner" :class="getBannerClass(banner)">
-                            <div class="welcome-banner-header">
-                                <span class="material-symbols-outlined welcome-banner-icon"
-                                    x-text="getBannerIcon(banner.type)"></span>
-                                <div class="welcome-banner-title" x-text="banner.title"></div>
-                            </div>
-                            <div class="welcome-banner-body" x-html="banner.html"></div>
-                        </div>
-                    </template>
-                </div>
+                <!-- Contextual Banners (Floating at bottom) -->
+                <x-component path="banners/banners.html"></x-component>
             </div>
         </template>
     </div>
@@ -146,89 +135,6 @@
             max-width: 520px;
             width: 100%;
             margin: 1.5rem 0;
-        }
-
-        .welcome-banners {
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-            width: min(720px, 100%);
-            margin-top: 0.5rem;
-            text-align: left;
-        }
-
-        .welcome-banner {
-            background: var(--color-panel);
-            border: 1px solid var(--color-border);
-            border-left-width: 4px;
-            border-radius: 12px;
-            padding: 1rem 1.2rem;
-            display: flex;
-            flex-direction: column;
-            gap: 0.6rem;
-            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-        }
-
-        .welcome-banner-info {
-            border-left-color: var(--color-highlight);
-        }
-
-        .welcome-banner-warning {
-            border-left-color: var(--color-accent);
-        }
-
-        .welcome-banner-error {
-            border-left-color: var(--color-accent);
-        }
-
-        .welcome-banner-header {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-
-        .welcome-banner-icon {
-            font-size: 1.4rem;
-            color: var(--color-highlight);
-        }
-
-        .welcome-banner-warning .welcome-banner-icon,
-        .welcome-banner-error .welcome-banner-icon {
-            color: var(--color-accent);
-        }
-
-        .welcome-banner-title {
-            font-size: 1rem;
-            font-weight: 600;
-        }
-
-        .welcome-banner-body {
-            font-size: 0.9rem;
-            color: var(--color-secondary);
-            line-height: 1.5;
-        }
-
-        .welcome-banner-body p {
-            margin: 0 0 0.6rem 0;
-        }
-
-        .welcome-banner-action {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0.4rem 0.8rem;
-            border-radius: 999px;
-            border: 1px solid var(--color-border);
-            background: var(--color-message-bg);
-            color: var(--color-text);
-            cursor: pointer;
-            font-size: 0.85rem;
-            transition: all 0.2s ease;
-        }
-
-        .welcome-banner-action:hover {
-            border-color: var(--color-primary);
-            color: var(--color-primary);
         }
 
         .welcome-action-card {
@@ -317,10 +223,6 @@
                 grid-template-columns: 1fr;
                 gap: 1rem;
                 margin-bottom: 2rem;
-            }
-
-            .welcome-banners {
-                width: 100%;
             }
 
             .welcome-action-card {

--- a/webui/components/welcome/welcome-screen.html
+++ b/webui/components/welcome/welcome-screen.html
@@ -67,6 +67,20 @@
                         </p>
                     </div>
                 </div>
+
+                <!-- Contextual Banners -->
+                <div class="welcome-banners" x-show="sortedBanners.length > 0">
+                    <template x-for="banner in sortedBanners" :key="banner.key">
+                        <div class="welcome-banner" :class="getBannerClass(banner)">
+                            <div class="welcome-banner-header">
+                                <span class="material-symbols-outlined welcome-banner-icon"
+                                    x-text="getBannerIcon(banner.type)"></span>
+                                <div class="welcome-banner-title" x-text="banner.title"></div>
+                            </div>
+                            <div class="welcome-banner-body" x-html="banner.html"></div>
+                        </div>
+                    </template>
+                </div>
             </div>
         </template>
     </div>
@@ -132,6 +146,89 @@
             max-width: 520px;
             width: 100%;
             margin: 1.5rem 0;
+        }
+
+        .welcome-banners {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            width: min(720px, 100%);
+            margin-top: 0.5rem;
+            text-align: left;
+        }
+
+        .welcome-banner {
+            background: var(--color-panel);
+            border: 1px solid var(--color-border);
+            border-left-width: 4px;
+            border-radius: 12px;
+            padding: 1rem 1.2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.6rem;
+            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+        }
+
+        .welcome-banner-info {
+            border-left-color: var(--color-highlight);
+        }
+
+        .welcome-banner-warning {
+            border-left-color: var(--color-accent);
+        }
+
+        .welcome-banner-error {
+            border-left-color: var(--color-accent);
+        }
+
+        .welcome-banner-header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .welcome-banner-icon {
+            font-size: 1.4rem;
+            color: var(--color-highlight);
+        }
+
+        .welcome-banner-warning .welcome-banner-icon,
+        .welcome-banner-error .welcome-banner-icon {
+            color: var(--color-accent);
+        }
+
+        .welcome-banner-title {
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        .welcome-banner-body {
+            font-size: 0.9rem;
+            color: var(--color-secondary);
+            line-height: 1.5;
+        }
+
+        .welcome-banner-body p {
+            margin: 0 0 0.6rem 0;
+        }
+
+        .welcome-banner-action {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.4rem 0.8rem;
+            border-radius: 999px;
+            border: 1px solid var(--color-border);
+            background: var(--color-message-bg);
+            color: var(--color-text);
+            cursor: pointer;
+            font-size: 0.85rem;
+            transition: all 0.2s ease;
+        }
+
+        .welcome-banner-action:hover {
+            border-color: var(--color-primary);
+            color: var(--color-primary);
         }
 
         .welcome-action-card {
@@ -220,6 +317,10 @@
                 grid-template-columns: 1fr;
                 gap: 1rem;
                 margin-bottom: 2rem;
+            }
+
+            .welcome-banners {
+                width: 100%;
             }
 
             .welcome-action-card {

--- a/webui/components/welcome/welcome-store.js
+++ b/webui/components/welcome/welcome-store.js
@@ -1,20 +1,146 @@
 import { createStore } from "/js/AlpineStore.js";
+import * as API from "/js/api.js";
 import { getContext } from "/index.js";
 import { store as chatsStore } from "/components/sidebar/chats/chats-store.js";
 import { store as memoryStore } from "/components/modals/memory/memory-dashboard-store.js";
 import { store as projectsStore } from "/components/projects/projects-store.js";
+import { store as settingsStore } from "/components/settings/settings-store.js";
+import {
+  store as bannerStore,
+  BANNER_TYPES,
+  BANNER_PRIORITY,
+} from "/components/banners/banner-store.js";
+
+const LOCAL_PROVIDER_IDS = new Set(["ollama", "lm_studio", "lmstudio"]);
+
+const isLoopbackHost = (hostname) => {
+  if (!hostname) return false;
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "0.0.0.0" ||
+    normalized.endsWith(".localhost")
+  ) {
+    return true;
+  }
+  if (/^127(?:\.\d{1,3}){3}$/.test(normalized)) {
+    return true;
+  }
+  return false;
+};
+
+const normalizeProviderId = (provider) =>
+  provider ? provider.toLowerCase().replace(/\s+/g, "_") : "";
+
+const isLocalProvider = (provider) =>
+  LOCAL_PROVIDER_IDS.has(normalizeProviderId(provider));
+
+const registerWelcomeBannerChecks = (() => {
+  let registered = false;
+  return () => {
+    if (registered) return;
+    registered = true;
+
+    bannerStore.registerCheck("welcome", ({ context, settings }) => {
+      const isLocal = isLoopbackHost(context?.hostname);
+      const hasCredentials = Boolean(
+        settings?.auth_login && settings?.auth_password
+      );
+      if (isLocal || hasCredentials) return [];
+      return [
+        bannerStore.createBanner({
+          id: "welcome-unsecured-connection",
+          title: "Unsecured connection",
+          type: BANNER_TYPES.WARNING,
+          priority: BANNER_PRIORITY.HIGH,
+          html: `
+            <p>
+              This instance is reachable from a non-local address without authentication.
+              Add credentials to protect access from the internet.
+            </p>
+            <button class="welcome-banner-action" type="button"
+              @click="openSettingsTab('external')">
+              Configure credentials
+            </button>
+          `,
+        }),
+      ];
+    });
+
+    bannerStore.registerCheck("welcome", ({ context, settings }) => {
+      const isLocal = isLoopbackHost(context?.hostname);
+      const hasCredentials = Boolean(
+        settings?.auth_login && settings?.auth_password
+      );
+      if (!hasCredentials || isLocal || context?.protocol === "https") return [];
+      return [
+        bannerStore.createBanner({
+          id: "welcome-credentials-plaintext",
+          title: "Credentials may be sent unencrypted",
+          type: BANNER_TYPES.WARNING,
+          priority: BANNER_PRIORITY.MEDIUM,
+          html: `
+            <p>
+              Authentication is enabled but this connection is not using HTTPS.
+              Credentials could be intercepted on the network.
+            </p>
+          `,
+        }),
+      ];
+    });
+
+    bannerStore.registerCheck("welcome", ({ settings }) => {
+      const selectedProvider = settings?.chat_model_provider;
+      const apiKeyValue = selectedProvider
+        ? settings?.api_keys?.[selectedProvider]
+        : "";
+      if (!selectedProvider || isLocalProvider(selectedProvider) || apiKeyValue) {
+        return [];
+      }
+      return [
+        bannerStore.createBanner({
+          id: "welcome-missing-api-key",
+          title: "Missing API key for models",
+          type: BANNER_TYPES.ERROR,
+          priority: BANNER_PRIORITY.HIGH,
+          html: `
+            <p>
+              The selected provider does not have an API key configured.
+              Agent Zero will not be able to run until one is added.
+            </p>
+            <button class="welcome-banner-action" type="button"
+              @click="openSettingsTab('external')">
+              Add API key
+            </button>
+          `,
+        }),
+      ];
+    });
+  };
+})();
 
 const model = {
   // State
   isVisible: true,
+  banners: [],
+  bannerChecksInFlight: false,
 
   init() {
+    registerWelcomeBannerChecks();
     // Initialize visibility based on current context
     this.updateVisibility();
+    if (this.isVisible) {
+      this.refreshBanners();
+    }
 
     // Watch for context changes with faster polling for immediate response
     setInterval(() => {
+      const wasVisible = this.isVisible;
       this.updateVisibility();
+      if (this.isVisible && !wasVisible) {
+        this.refreshBanners();
+      }
     }, 50); // 50ms for very responsive updates
   },
 
@@ -32,6 +158,88 @@ const model = {
   // Show welcome screen
   show() {
     this.isVisible = true;
+    this.refreshBanners();
+  },
+
+  get sortedBanners() {
+    return bannerStore.sortBanners(this.banners);
+  },
+
+  getBannerClass(banner) {
+    return bannerStore.getBannerClass(banner?.type, "welcome-banner");
+  },
+
+  getBannerIcon(type) {
+    return bannerStore.getBannerIcon(type);
+  },
+
+  async loadSettingsSnapshot() {
+    try {
+      const response = await API.callJsonApi("settings_get", null);
+      return response;
+    } catch (error) {
+      console.error("Failed to load settings for banners:", error);
+      return null;
+    }
+  },
+
+  buildBannerContext(settingsSnapshot) {
+    const location = new URL(window.location.href);
+    return {
+      url: window.location.href,
+      hostname: location.hostname,
+      protocol: location.protocol.replace(":", ""),
+      browser: navigator.userAgent,
+      time: new Date().toISOString(),
+      selected_provider: settingsSnapshot?.settings?.chat_model_provider || null,
+    };
+  },
+
+  runFrontendBannerChecks(context, settingsSnapshot) {
+    const settings = settingsSnapshot?.settings || {};
+    const additional = settingsSnapshot?.additional || {};
+    const input = { context, settings, additional };
+    return bannerStore.runChecks("welcome", input);
+  },
+
+  async runBackendBannerChecks(frontendBanners, context) {
+    try {
+      const response = await API.callJsonApi("welcome_banners", {
+        context,
+        frontend_banners: frontendBanners,
+      });
+      if (Array.isArray(response?.banners)) {
+        return response.banners;
+      }
+      return [];
+    } catch (error) {
+      console.error("Failed to load backend banners:", error);
+      return [];
+    }
+  },
+
+  async refreshBanners() {
+    if (this.bannerChecksInFlight) return;
+    this.bannerChecksInFlight = true;
+    try {
+      const settingsSnapshot = await this.loadSettingsSnapshot();
+      const context = this.buildBannerContext(settingsSnapshot);
+      const frontendBanners = this.runFrontendBannerChecks(
+        context,
+        settingsSnapshot
+      );
+      const backendBanners = await this.runBackendBannerChecks(
+        frontendBanners,
+        context
+      );
+      this.banners = bannerStore.mergeBanners(frontendBanners, backendBanners);
+    } finally {
+      this.bannerChecksInFlight = false;
+    }
+  },
+
+  openSettingsTab(tab) {
+    settingsStore.open(tab || null);
   },
 
   // Execute an action by ID

--- a/webui/index.css
+++ b/webui/index.css
@@ -49,6 +49,8 @@
   --color-border: var(--color-border-dark);
   --color-input: var(--color-input-dark);
   --color-input-focus: var(--color-input-focus-dark);
+  --color-warning: #f1c40f;
+  --color-error: var(--color-accent);
   --color-background-hover: color-mix(in srgb, var(--color-border) 50%, transparent);
 
   /* Spacing variables */
@@ -89,6 +91,8 @@
   --color-border: var(--color-border-light);
   --color-input: var(--color-input-light);
   --color-input-focus: var(--color-input-focus-light);
+  --color-warning: #fbc02d;
+  --color-error: var(--color-accent);
   --color-background-hover: color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 


### PR DESCRIPTION
### Motivation
- Centralize banner logic so UI screens can reuse banner creation, normalization, merging, sorting, and presentation helpers.
- Surface contextual warnings on the Welcome screen (unsecured connection, plaintext credentials, missing API keys) to improve user guidance.
- Reduce duplicated banner UI code by moving class/icon helpers into the shared banner store for consistency across screens.
- Prevent attempts to set the system `root_password` when the value is empty or equals the placeholder to avoid errors in non-docker environments.

### Description
- Add a reusable `webui/components/banners/banner-store.js` implementing `registerCheck`, `runChecks`, `createBanner`, `normalizeBanner`, `assignBannerKeys`, `mergeBanners`, `sortBanners`, `getBannerClass`, and `getBannerIcon` and expose a `bannerStore` for consumers.
- Refactor `webui/components/welcome/welcome-store.js` to register welcome banner checks in `bannerStore`, build a banner context, run frontend/backend checks via `bannerStore.runChecks`, merge results with `bannerStore.mergeBanners`, and use `bannerStore.sortBanners`, `getBannerClass`, and `getBannerIcon` for rendering.
- Update `webui/components/welcome/welcome-screen.html` to render the contextual banners UI, include styling and action buttons, and wire actions to open the appropriate settings tab.
- Add a backend API stub `python/api/welcome_banners.py` that returns `{"banners": []}` and change `python/helpers/settings.py` to only call `dotenv.save_dotenv_value` and `set_root_password` when `settings["root_password"]` is truthy and not equal to `PASSWORD_PLACEHOLDER`.

### Testing
- Started the UI server with `python run_ui.py --host 0.0.0.0`, which launched successfully but reported warnings about a missing RFC password and a failed model preload.
- Ran a Playwright script to capture the welcome screen and successfully saved `artifacts/welcome-banners.png`.
- No automated unit tests were executed for these changes.
- The small follow-up commit moving `getBannerClass`/`getBannerIcon` into `banner-store` was applied without additional automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da44f8570832e9513643e11dd6a07)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes banner logic and surfaces contextual guidance on the Welcome screen.
> 
> - Adds `webui/components/banners/banner-store.js` with banner creation/normalization, merge/sort, class/icon helpers, and a scoped `registerCheck`/`runChecks` API
> - Refactors `welcome-store.js` to register “welcome” checks (unsecured connection, plaintext creds, missing API key), build context, fetch settings, run frontend + backend checks, and merge/sort results; exposes actions like `openSettingsTab`
> - Renders floating banners via new `banners.html` and includes it in `welcome-screen.html` with action buttons
> - Adds backend API stub `python/api/welcome_banners.py` returning `{"banners": []}` for future server-provided banners
> - Updates `index.css` with `--color-warning`/`--color-error` variables for banner styling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61c2ce97f7e3d19c3ec2a57f6ab1521eb25874a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->