### PR TITLE
Add missing API key status endpoint and update composer banner to use it

### DIFF
--- a/plugins/_model_config/api/missing_api_key_status.py
+++ b/plugins/_model_config/api/missing_api_key_status.py
@@ -1,0 +1,11 @@
+from helpers.api import ApiHandler, Request, Response
+from plugins._model_config.helpers import model_config
+
+
+class MissingApiKeyStatus(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        missing_providers = model_config.get_missing_api_key_providers()
+        return {
+            "missing_providers": missing_providers,
+            "has_missing_api_keys": bool(missing_providers),
+        }

--- a/tests/test_model_config_api_keys.py
+++ b/tests/test_model_config_api_keys.py
@@ -45,6 +45,7 @@ sys.modules["watchdog.observers"] = watchdog.observers
 sys.modules["watchdog.events"] = watchdog.events
 
 from plugins._model_config.api.api_keys import ApiKeys
+from plugins._model_config.api.missing_api_key_status import MissingApiKeyStatus
 from plugins._model_config.extensions.python.banners import _20_missing_api_key as missing_key_banner
 import models
 
@@ -83,12 +84,29 @@ async def test_missing_api_key_banner_exposes_missing_providers(monkeypatch):
     assert row.get("missing_providers") == fake
 
 
+@pytest.mark.asyncio
+async def test_missing_api_key_status_endpoint_returns_missing_providers(monkeypatch):
+    from plugins._model_config.helpers import model_config
+
+    fake = [{"model_type": "Chat Model", "provider": "openrouter"}]
+    monkeypatch.setattr(model_config, "get_missing_api_key_providers", lambda: fake)
+
+    handler = MissingApiKeyStatus(Flask(__name__), threading.Lock())
+    data = await handler.process({}, None)
+    assert data == {
+        "missing_providers": fake,
+        "has_missing_api_keys": True,
+    }
+
+
 def test_model_config_frontend_tracks_inline_api_key_edits():
     store_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "model-config-store.js"
+    composer_store_path = PROJECT_ROOT / "webui" / "components" / "chat" / "input" / "composer-banner-store.js"
     config_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "config.html"
     modal_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "api-keys.html"
 
     store_content = store_path.read_text(encoding="utf-8")
+    composer_store_content = composer_store_path.read_text(encoding="utf-8")
     config_content = config_path.read_text(encoding="utf-8")
     modal_content = modal_path.read_text(encoding="utf-8")
 
@@ -96,6 +114,8 @@ def test_model_config_frontend_tracks_inline_api_key_edits():
     assert "resetApiKeyDrafts()" in store_content
     assert "!provider || seen.has(provider) || !this.apiKeyDirty[provider]" in store_content
     assert "normalized[provider] = value.trim() ? value : '';" in store_content
+    assert "/plugins/_model_config/missing_api_key_status" in composer_store_content
+    assert 'callJsonApi("/banners"' not in composer_store_content
     assert "$store.modelConfig.resetApiKeyDrafts();" in config_content
     assert '@input="$store.modelConfig.touchApiKey(config[section.key].provider)"' in config_content
     assert "updates[provider] = this.keys[provider] || '';" in modal_content

--- a/webui/components/chat/input/composer-banner-store.js
+++ b/webui/components/chat/input/composer-banner-store.js
@@ -1,8 +1,6 @@
 import { createStore } from "/js/AlpineStore.js";
 import { callJsonApi } from "/js/api.js";
 
-const MISSING_API_KEY_BANNER_ID = "missing-api-key";
-
 function buildBannersContext() {
   return {
     url: window.location.href,
@@ -47,14 +45,11 @@ export const store = createStore("composerBanner", {
     this.lastRefresh = now;
     this.loading = true;
     try {
-      const response = await callJsonApi("/banners", {
-        banners: [],
+      const response = await callJsonApi("/plugins/_model_config/missing_api_key_status", {
         context: buildBannersContext(),
       });
-      const list = response?.banners || [];
-      const row = list.find((b) => b?.id === MISSING_API_KEY_BANNER_ID);
-      this.missingApiKeys = Array.isArray(row?.missing_providers)
-        ? row.missing_providers
+      this.missingApiKeys = Array.isArray(response?.missing_providers)
+        ? response.missing_providers
         : [];
     } catch (e) {
       console.error("composerBanner refresh failed", e);


### PR DESCRIPTION
### Motivation
- Expose missing API key information via a lightweight API endpoint so the composer can fetch missing-provider data without going through the generic banners endpoint.

### Description
- Add `plugins/_model_config/api/missing_api_key_status.py` which implements `MissingApiKeyStatus` and returns `missing_providers` and `has_missing_api_keys` from `model_config.get_missing_api_key_providers()`.
- Update `webui/components/chat/input/composer-banner-store.js` to call `"/plugins/_model_config/missing_api_key_status"` and read `missing_providers` directly instead of requesting `/banners` and searching for a specific banner ID.
- Add and adapt tests in `tests/test_model_config_api_keys.py` to include `test_missing_api_key_status_endpoint_returns_missing_providers` and to assert the composer store references the new endpoint.

### Testing
- Ran the related unit tests in `tests/test_model_config_api_keys.py`, including the new `test_missing_api_key_status_endpoint_returns_missing_providers`, and they passed under `pytest`.
- Verified the banner store logic by asserting the updated `composer-banner-store.js` contains the new endpoint and no longer calls `"/banners"` as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68fca88c4832ea7ab7b9494401cf9)