### PR TITLE
Rebase README links and images to correct GitHub blob/raw paths

### DIFF
--- a/plugins/_plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/_plugin_installer/webui/pluginInstallStore.js
@@ -97,30 +97,68 @@ const model = {
       .split("/");
     if (!owner || !repo) return html;
 
-    const repoBlobBase = `https://github.com/${owner}/${repo}/blob/${branch}`;
+    const repoWebBase = `https://github.com/${owner}/${repo}`;
+    const repoBlobBase = `${repoWebBase}/blob/${branch}`;
+    const repoRawBase = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}`;
     const doc = new DOMParser().parseFromString(html, "text/html");
+    const githubRepoRoutePrefixes = new Set([
+      "actions",
+      "blob",
+      "branches",
+      "commit",
+      "commits",
+      "compare",
+      "discussions",
+      "issues",
+      "labels",
+      "milestones",
+      "packages",
+      "projects",
+      "pulls",
+      "raw",
+      "releases",
+      "security",
+      "tags",
+      "tree",
+      "wiki",
+    ]);
+    const shouldSkipRebase = (value) =>
+      !value ||
+      value.startsWith("#") ||
+      value.startsWith("//") ||
+      /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+
+    const resolveRepoPath = (value) => {
+      if (shouldSkipRebase(value)) return null;
+      try {
+        const resolved = new URL(value, "https://repo-root.invalid/");
+        return `${resolved.pathname.replace(/^\/+/, "")}${resolved.search}${resolved.hash}`;
+      } catch {
+        return null;
+      }
+    };
+    const isRepoRoutePath = (repoPath) => {
+      const pathOnly = repoPath
+        .split(/[?#]/, 1)[0]
+        .replace(/^\/+|\/+$/g, "");
+      if (!pathOnly) return false;
+      const firstSegment = pathOnly.split("/")[0].toLowerCase();
+      return githubRepoRoutePrefixes.has(firstSegment);
+    };
 
     doc.querySelectorAll("a[href]").forEach((anchor) => {
       const href = (anchor.getAttribute("href") || "").trim();
-      if (
-        !href ||
-        href.startsWith("#") ||
-        href.startsWith("//") ||
-        /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(href)
-      ) {
-        return;
-      }
+      const repoPath = resolveRepoPath(href);
+      if (!repoPath) return;
+      const base = isRepoRoutePath(repoPath) ? repoWebBase : repoBlobBase;
+      anchor.setAttribute("href", `${base}/${repoPath}`);
+    });
 
-      try {
-        const resolved = new URL(href, "https://repo-root.invalid/");
-        const repoPath = resolved.pathname.replace(/^\/+/, "");
-        anchor.setAttribute(
-          "href",
-          `${repoBlobBase}/${repoPath}${resolved.search}${resolved.hash}`,
-        );
-      } catch {
-        // Leave malformed links unchanged.
-      }
+    doc.querySelectorAll("img[src]").forEach((image) => {
+      const src = (image.getAttribute("src") || "").trim();
+      const repoPath = resolveRepoPath(src);
+      if (!repoPath) return;
+      image.setAttribute("src", `${repoRawBase}/${repoPath}`);
     });
 
     return doc.body.innerHTML;


### PR DESCRIPTION
### Motivation
- Ensure README links and images from GitHub repos are rewritten to point to the correct GitHub web/blob/raw URLs when rendering plugin READMEs. 
- Avoid rewriting external, fragment, protocol-relative, or fully-qualified URLs and correctly detect repository route paths that should use the web base instead of the blob base.

### Description
- Compute `repoWebBase`, `repoBlobBase`, and `repoRawBase` from the repository URL and branch to use appropriate targets for links and assets.  
- Add a set of `githubRepoRoutePrefixes` and helper functions `shouldSkipRebase`, `resolveRepoPath`, and `isRepoRoutePath` to robustly classify href/src values and skip invalid or external URLs.  
- Rewrite anchor `href` attributes to use either the web base or blob base depending on the path, and rewrite image `src` attributes to use the raw content base.  
- Replace the previous per-anchor try/catch URL resolution with centralized resolution logic and safer checks for when rebasing should occur.

### Testing
- Ran existing unit tests covering the plugin installer web UI (via the project's test suite); all tests passed.  
- Ran integration UI checks for README rendering with various link types; no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c0686f14832eb5aba1411d4b8941)